### PR TITLE
CustomTypeTest.testTestCase1 fails due to whitespace; corrected

### DIFF
--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/customTool/testcase1/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/customTool/testcase1/result.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite errors="0" failures="1" tests="6" name="cppunit">
-    <testcase classname="MathTest" name="testSum" time="0">
-        <failure message="equality assertion failed - Expected: 141496748 - Actual : 16777217"
-                 type="Assertion"/>
-        <system-err>&#xD;[File] - mathTest.cpp&#xD;[Line] - 56&#xD;</system-err>
-    </testcase>
-    <testcase classname="MathTest" name="testConstructor" time="0"/>
-    <testcase classname="MathTest" name="testPush" time="0"/>
-    <testcase classname="ExpressionTest" name="testConstructor" time="0"/>
-    <testcase classname="ExpressionTest" name="testPush" time="0"/>
-    <testcase classname="ExpressionTest" name="testSkipped" time="0">
-        <skipped/>
-    </testcase>
+   <testcase classname="MathTest" name="testSum" time="0">
+      <failure message="equality assertion failed - Expected: 141496748 - Actual : 16777217"
+             type="Assertion"/>
+      <system-err>&#xD;[File] - mathTest.cpp&#xD;[Line] - 56&#xD;</system-err>
+   </testcase>
+   <testcase classname="MathTest" name="testConstructor" time="0"/>
+   <testcase classname="MathTest" name="testPush" time="0"/>
+   <testcase classname="ExpressionTest" name="testConstructor" time="0"/>
+   <testcase classname="ExpressionTest" name="testPush" time="0"/>
+   <testcase classname="ExpressionTest" name="testSkipped" time="0">
+      <skipped/>
+   </testcase>
 </testsuite>


### PR DESCRIPTION
The issue was that the test emitted 3 spaces where the expectation file had 4.

https://jenkins.ci.cloudbees.com/job/plugins/job/xunit-plugin/org.jenkins-ci.plugins$xunit/lastCompletedBuild/testReport/org.jenkinsci.plugins.xunit.types/CustomTypeTest/testTestCase1/

in general, the test failure message wasn't helpful and should be revisited.
