### PR TITLE
Fix for JENKINS-17438

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -187,7 +187,7 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable {
         return Util.replaceMacro(newExpandedPattern, build.getEnvironment(listener));
     }
 
-private XUnitToolInfo getXUnitToolInfoObject(TestType tool, String expandedPattern, AbstractBuild build, BuildListener listener) throws IOException {
+private XUnitToolInfo getXUnitToolInfoObject(TestType tool, String expandedPattern, AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
         return new XUnitToolInfo(
                 new FilePath(new File(Hudson.getInstance().getRootDir(), "userContent")),
                 tool.getInputMetric(),


### PR DESCRIPTION
Updated getXUnitToolInfoObject() to include:
 \* BuildListener parameter
 \* Use Util.replaceMacro() to expand CustomXSL string

Updated performTests() call to getXUnitToolInfoObject() to include BuildListener parameter
 \* Searched rest of the code, this seems to be the only call of getXUnitToolInfoObject()

Addresses Bug: https://issues.jenkins-ci.org/browse/JENKINS-17438
