### PR TITLE
Add support for Erlang/OTP Junit format

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitInputMetric.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitInputMetric.java
@@ -6,7 +6,7 @@ import com.thalesgroup.dtkit.util.validator.ValidationError;
 import com.thalesgroup.dtkit.util.validator.ValidationException;
 import hudson.FilePath;
 import org.apache.commons.io.FileUtils;
-import org.jenkinsci.plugins.xunit.types.model.JUnit9;
+import org.jenkinsci.plugins.xunit.types.model.JUnit10;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class JUnitInputMetric extends InputMetricOther {
 
     @Override
     public boolean validateInputFile(File inputXMLFile) throws ValidationException {
-        final JUnit9 jUnit = new JUnit9();
+        final JUnit10 jUnit = new JUnit10();
         List<ValidationError> errors = jUnit.validate(inputXMLFile);
         for (ValidationError error : errors) {
             System.out.println(error);

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/model/JUnit10.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/model/JUnit10.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.xunit.types.model;
+
+import com.thalesgroup.dtkit.metrics.model.AbstractOutputMetric;
+
+import java.io.Serializable;
+
+/**
+ * @author Gregory Boissinot
+ */
+public class JUnit10 extends AbstractOutputMetric implements Serializable {
+
+    @Override
+    public String getKey() {
+        return "junit";
+    }
+
+    @Override
+    public String getDescription() {
+        return "JUNIT OUTPUT FORMAT 10.0";
+    }
+
+    @Override
+    public String getVersion() {
+        return "10.0";
+    }
+
+    @Override
+    public String[] getXsdNameList() {
+        return new String[]{"xsd/junit-10.xsd"};
+    }
+}
+
+
+

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element ref="skipped"/>
+                    <xs:element ref="error"/>
+                    <xs:element ref="failure"/>
+                    <xs:element ref="system-out"/>
+                    <xs:element ref="system-err"/>
+                </xs:choice>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+            <xs:attribute name="class" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:string" use="optional"/>
+            <xs:attribute name="log" type="xs:string" use="optional"/>
+            <xs:attribute name="group" type="xs:string" use="optional"/>
+            <xs:attribute name="url" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="testsuite"/>
+                <xs:element ref="properties"/>
+                <xs:element ref="testcase"/>
+                <xs:element ref="system-out"/>
+                <xs:element ref="system-err"/>
+            </xs:choice>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="skips" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="skip" type="xs:string" use="optional"/>
+            <xs:attribute name="log" type="xs:string" use="optional"/>
+            <xs:attribute name="url" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
The Common Test framework in Erlang/OTP can create Jenkins/Hudson
compatible Junit reports since R15B. In xunit 1.54 these files are
correctly consumed and rendered by the xUnit plugin.

However in more recent versions the files are not parsed correctly due
to some extra attributes. This adds support for these attributes. The
standard Jenkins Junit plugin consumes these files correctly.
