### PR TITLE
JENKINS-21220 - Make XUnitProcessor serializable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
@@ -1,9 +1,13 @@
 package org.jenkinsci.plugins.xunit;
 
+import java.io.Serializable;
+
 /**
  * @author Gregory Boissinot
  */
-public class ExtraConfiguration {
+public class ExtraConfiguration implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final long testTimeMargin;
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -23,12 +23,13 @@ import org.jenkinsci.plugins.xunit.types.CustomType;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * @author Gregory Boissinot
  */
-public class XUnitProcessor {
-
+public class XUnitProcessor implements Serializable {
+    private static final long serialVersionUID = 1L;
     private TestType[] types;
     private XUnitThreshold[] thresholds;
     private int thresholdMode;


### PR DESCRIPTION
When processing xUnit files on remote SSH slaves the following error
was obserserved:

 The plugin hasn't been performed correctly: remote file operation failed: /home/jenkins/workspace/xunit at hudson.remoting.Channel@56f87a20:slave

When investigating it was found that a NotSerializableException was
thrown. Simply make the needed classes serializable.
