### PR TITLE
Aggregate multiple failures in GoogleTest output to a single failure in JUnit

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/googletest-to-junit-4.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/googletest-to-junit-4.xsl
@@ -27,14 +27,18 @@
 			<xsl:if test="failure">
 				<failure>
 					<xsl:for-each select="failure">
+						<xsl:if test="not(position()=1)">
+							<xsl:text>&#xa;&#xa;</xsl:text>
+						</xsl:if>
 						<xsl:value-of select="@message"/>
-						<xsl:text>&#xa;&#xa;</xsl:text>
 					</xsl:for-each>
 				</failure>
 				<system-out>
 					<xsl:for-each select="failure">
+						<xsl:if test="not(position()=1)">
+							<xsl:text>&#xa;&#xa;</xsl:text>
+						</xsl:if>
 						<xsl:value-of select="."/>
-						<xsl:text>&#xa;&#xa;</xsl:text>
 					</xsl:for-each>
 				</system-out>
 			</xsl:if>


### PR DESCRIPTION
A test can have multiple failures in GoogleTest (for example if recursive ASSERT_NO_FATAL_FAILURES are used), but a testcase in JUnit xml format can only have one failure at most.
The modified xsl file concatenates all the failures into a single one.
