### PR TITLE
[JENKINS-21532] Fixed wrong placed <br>s.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -29,8 +29,10 @@
 
     </f:block>
 
-    <br/>
-    <br/>
+    <f:block>
+        <br/>
+        <br/>
+    </f:block>
 
     <!-- Extra Configuration -->
     <f:block>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -29,8 +29,10 @@
 
     </f:block>
 
-    <br/>
-    <br/>
+    <f:block>
+        <br/>
+        <br/>
+    </f:block>
 
     <!-- Extra Configuration -->
     <f:block>


### PR DESCRIPTION
<br><br> before Extra Configuration block is placed in bad place in HTML and confuses browsers.
Especially combined with [Flexible Publish Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Flexible+Publish+Plugin), it cause drop-down lists not work.

This patch generates correct HTMLs.

See
https://issues.jenkins-ci.org/browse/JENKINS-21532
https://issues.jenkins-ci.org/browse/JENKINS-21497
for more details.
