### PR TITLE
Fix JENKINS-18443

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -122,7 +122,6 @@ public class XUnitProcessor implements Serializable {
 
                     if (ie instanceof SkipTestException) {
                         xUnitLog.infoConsoleLogger("Skipping the metric tool processing.");
-                        findTest = false;
                         continue;
                     }
 
@@ -137,8 +136,6 @@ public class XUnitProcessor implements Serializable {
                     throw new StopTestProcessingException();
                 }
             }
-
-
         }
         return findTest;
     }


### PR DESCRIPTION
If we have 2 tests, A and B, both having the "Skip if there are no test
files" checkbox checked and parser A has test files, but parser B
doesn't. The result of parser A is ignored because parser B doesn't have
any files.

I see the reason of the line added for JENKINS-18443, but that just
hides the real problem.
