### PR TITLE
Recognize ctest 'notrun' as skipped.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/ctest-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/ctest-to-junit.xsl
@@ -19,11 +19,17 @@
                     <testcase classname="projectroot{$className}"
                               name="{$testName}"
                               time="{$duration}">
-                        <xsl:if test="@Status!='passed'">
-                            <failure>
-                                <xsl:value-of select="$output"/>
-                            </failure>
-                        </xsl:if>
+                        <xsl:choose>
+                            <xsl:when test="@Status='passed'"/>
+                            <xsl:when test="@Status='notrun'">
+                                <skipped/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <failure>
+                                    <xsl:value-of select="$output"/>
+                                </failure>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         <system-out>
                             <xsl:value-of select="$output"/>
                         </system-out>

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/CTestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/CTestTest.java
@@ -10,6 +10,7 @@ public class CTestTest extends AbstractTest {
     @Test
     public void testTestCase1() throws Exception {
         convertAndValidate(CTestInputMetric.class, "ctest/testcase1/input.xml", "ctest/testcase1/result.xml");
+        convertAndValidate(CTestInputMetric.class, "ctest/testcase2/input.xml", "ctest/testcase2/result.xml");
     }
 
 }

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/ctest/testcase2/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/ctest/testcase2/input.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="(empty)"
+	BuildStamp="20140603-1905-Experimental"
+	Name="(empty)"
+	Generator="ctest-3.0.0-rc6"
+	CompilerName=""
+	OSName="Mac OS X"
+	Hostname="localhost"
+	OSRelease="10.9.2"
+	OSVersion="13C64"
+	OSPlatform="x86_64"
+	Is64Bits="0"
+	VendorString="GenuineIntel"
+	VendorID="Intel Corporation"
+	FamilyID="6"
+	ModelID="23"
+	ProcessorCacheSize="32768"
+	NumberOfLogicalCPU="2"
+	NumberOfPhysicalCPU="2"
+	TotalVirtualMemory="1024"
+	TotalPhysicalMemory="6144"
+	LogicalProcessorsPerPhysical="2"
+	ProcessorClockFrequency="2278"
+>
+<Testing>
+	<StartDateTime>Jun 03 20:05 BST</StartDateTime>
+	<StartTestTime>1401822355</StartTestTime>
+	<TestList>
+		<Test>./app_gl_default_sb</Test>
+	</TestList>
+	<Test Status="notrun">
+		<Name>app_gl_default_sb</Name>
+		<Path>.</Path>
+		<FullName>./app_gl_default_sb</FullName>
+		<FullCommandLine>/usr/bin/python &quot;/var/lib/hudson/workspace/apitrace-mac-test/app_driver.py&quot; &quot;--apitrace&quot; &quot;/var/lib/hudson/workspace/apitrace-mac/apitrace&quot; &quot;--apitrace-source&quot; &quot;/var/lib/hudson/workspace/apitrace-mac&quot; &quot;--api&quot; &quot;gl&quot; &quot;--ref-dump&quot; &quot;/var/lib/hudson/workspace/apitrace-mac-test/apps/gl/default_sb.ref.txt&quot; &quot;--&quot; &quot;/var/lib/hudson/workspace/apitrace-mac-test/apps/gl/tri&quot; &quot;-sb&quot;</FullCommandLine>
+		<Results>
+			<NamedMeasurement type="text/string" name="Command Line"><Value>/usr/bin/python &quot;/var/lib/hudson/workspace/apitrace-mac-test/app_driver.py&quot; &quot;--apitrace&quot; &quot;/var/lib/hudson/workspace/apitrace-mac/apitrace&quot; &quot;--apitrace-source&quot; &quot;/var/lib/hudson/workspace/apitrace-mac&quot; &quot;--api&quot; &quot;gl&quot; &quot;--ref-dump&quot; &quot;/var/lib/hudson/workspace/apitrace-mac-test/apps/gl/default_sb.ref.txt&quot; &quot;--&quot; &quot;/var/lib/hudson/workspace/apitrace-mac-test/apps/gl/tri&quot; &quot;-sb&quot;</Value></NamedMeasurement>
+			<Measurement>
+				<Value>Run application...
+DRY_RUN=yes /var/lib/hudson/workspace/apitrace-mac-test/apps/gl/tri -sb
+SKIP (application returned code 125)
+</Value>
+			</Measurement>
+		</Results>
+	</Test>
+	<EndDateTime>Jun 03 20:05 BST</EndDateTime>
+	<EndTestTime>1401822356</EndTestTime>
+<ElapsedMinutes>0</ElapsedMinutes></Testing>
+</Site>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/ctest/testcase2/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/ctest/testcase2/result.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="CTest" tests="1" time="0" failures="1" errors="0" skipped="0">
+    <testcase classname="projectroot" name="app_gl_default_sb" time="">
+      <skipped/>
+      <system-out>Run application...
+DRY_RUN=yes /var/lib/hudson/workspace/apitrace-mac-test/apps/gl/tri -sb
+SKIP (application returned code 125)
+</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
cmake 3.0 adds support for skipped tests, which are marked as not run:

  http://www.cmake.org/cmake/help/v3.0/prop_test/SKIP_RETURN_CODE.html#prop_test:SKIP_RETURN_CODE

PS: I haven't actually ran the test suite -- just ran the XSL manually
with xsltproc.
