### PR TITLE
xUnit Skipped Tests Threshold not work when percent mode 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
@@ -69,7 +69,7 @@ public class SkippedThreshold extends XUnitThreshold {
             previousSkippedCount = previousTestResultAction.getSkipCount();
         }
         int newSkippedCount = skippedCount - previousSkippedCount;
-        int percentNewSkipped = (count == 0) ? 0 : (newSkippedCount / count) * 100;
+        int percentNewSkipped = (count == 0) ? 0 : (newSkippedCount  * 100 / count);
 
         return getResultThresholdPercent(log, percentSkipped, percentNewSkipped);
     }


### PR DESCRIPTION
Update SkippedThreshold.java
Because (skippedCount / count) will be converted to int, its value is 0, so percentNewSkipped always gain 0.