### PR TITLE
Add support for gtester/glib2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/types/GTester.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/GTester.java
@@ -1,0 +1,68 @@
+/*
+* The MIT License (MIT)
+*
+* Copyright (c) 2015, Andre Klitzing
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+package org.jenkinsci.plugins.xunit.types;
+
+import org.jenkinsci.lib.dtkit.model.InputMetricXSL;
+import org.jenkinsci.lib.dtkit.model.InputType;
+import org.jenkinsci.lib.dtkit.model.OutputMetric;
+import org.jenkinsci.plugins.xunit.types.model.JUnitModel;
+
+public class GTester extends InputMetricXSL {
+
+    @Override
+    public InputType getToolType() {
+        return InputType.TEST;
+    }
+
+    @Override
+    public String getToolName() {
+        return "gtester/glib2";
+    }
+
+    @Override
+    public String getToolVersion() {
+        return "N/A";
+    }
+
+    @Override
+    public boolean isDefault() {
+        return true;
+    }
+
+    @Override
+    public String getXslName() {
+        return "gtester-to-junit-4.xsl";
+    }
+
+    @Override
+    public String[] getInputXsdNameList() {
+        return null;
+    }
+
+    @Override
+    public OutputMetric getOutputFormatType() {
+        return JUnitModel.LATEST;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/GTesterJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/GTesterJunitHudsonTestType.java
@@ -1,0 +1,52 @@
+/*
+* The MIT License (MIT)
+*
+* Copyright (c) 2015, Andre Klitzing
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+package org.jenkinsci.plugins.xunit.types;
+
+import hudson.Extension;
+import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
+import org.jenkinsci.lib.dtkit.type.TestType;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class GTesterJunitHudsonTestType extends TestType {
+
+    @DataBoundConstructor
+    public GTesterJunitHudsonTestType(String pattern, boolean skipNoTestFiles, boolean failIfNotNew, boolean deleteOutputFiles, boolean stopProcessingIfError) {
+        super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends TestTypeDescriptor<GTesterJunitHudsonTestType> {
+
+        public DescriptorImpl() {
+            super(GTesterJunitHudsonTestType.class, GTester.class);
+        }
+    }
+
+    @Override
+    public Object readResolve() {
+        return super.readResolve();
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/gtester-to-junit-4.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/gtester-to-junit-4.xsl
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<!-- created by R. Tyler Croy and improved by André Klitzing -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output indent="yes" method="xml" omit-xml-declaration="no" cdata-section-elements="system-out" />
+
+  <xsl:template name="strreplace">
+    <!-- Based on this code: http://geekswithblogs.net/Erik/archive/2008/04/01/120915.aspx -->
+    <xsl:param name="string" />
+    <xsl:param name="token" />
+    <xsl:param name="newtoken" />
+    <xsl:choose>
+      <xsl:when test="contains($string, $token)">
+        <xsl:value-of select="substring-before($string, $token)" />
+        <xsl:value-of select="$newtoken" />
+        <xsl:call-template name="strreplace">
+          <xsl:with-param name="string" select="substring-after($string, $token)" />
+          <xsl:with-param name="token" select="$token" />
+          <xsl:with-param name="newtoken" select="$newtoken" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$string" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="remove-lf-left">
+    <!-- Based on this code: http://dpawson.co.uk/xsl/sect2/N8321.html#d11325e833 -->
+    <xsl:param name="astr" />
+    <xsl:choose>
+      <xsl:when test="starts-with($astr,'&#xA;') or starts-with($astr,'&#xD;')">
+        <xsl:call-template name="remove-lf-left">
+          <xsl:with-param name="astr" select="substring($astr, 2)" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$astr" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="sysout">
+    random-seed: <xsl:value-of select="random-seed" />
+    <xsl:for-each select="testcase">
+      <xsl:variable name="classname">
+        <xsl:call-template name="strreplace">
+          <xsl:with-param name="string" select="substring-after(@path, '/')" />
+          <xsl:with-param name="token" select="'/'" />
+          <xsl:with-param name="newtoken" select="'.'" />
+        </xsl:call-template>
+      </xsl:variable>
+      Start test '<xsl:value-of select="$classname" />':
+      ---------------------------------------------------------------------
+      <xsl:for-each select="message">
+        <xsl:call-template name="remove-lf-left">
+          <xsl:with-param name="astr" select="." />
+        </xsl:call-template>
+      </xsl:for-each>
+      ---------------------------------------------------------------------
+      End test '<xsl:value-of select="$classname" />'
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="/">
+    <testsuites>
+      <xsl:for-each select="gtester">
+
+        <xsl:for-each select="testbinary">
+          <testsuite>
+            <xsl:attribute name="name">
+              <xsl:value-of select="@path" />
+            </xsl:attribute>
+            <xsl:attribute name="tests">
+              <xsl:value-of select="count(testcase)" />
+            </xsl:attribute>
+            <xsl:attribute name="time">
+              <xsl:value-of select="sum(testcase/duration)" />
+            </xsl:attribute>
+            <xsl:attribute name="failures">
+              <xsl:value-of select="count(testcase/status[@result='failed'])" />
+            </xsl:attribute>
+
+            <xsl:for-each select="testcase">
+              <testcase>
+                <xsl:variable name="classname">
+                  <xsl:call-template name="strreplace">
+                    <xsl:with-param name="string" select="substring-after(@path, '/')" />
+                    <xsl:with-param name="token" select="'/'" />
+                    <xsl:with-param name="newtoken" select="'.'" />
+                  </xsl:call-template>
+                </xsl:variable>
+                <xsl:attribute name="classname">
+                  <xsl:value-of select="$classname" />
+                </xsl:attribute>
+                <xsl:attribute name="name">
+                  <xsl:value-of select="$classname" />
+                </xsl:attribute>
+                <xsl:attribute name="time">
+                  <xsl:value-of select="duration" />
+                </xsl:attribute>
+                <xsl:if test="status[@result = 'failed']">
+                  <failure>
+                    <xsl:value-of select="error" />
+                  </failure>
+                </xsl:if>
+              </testcase>
+            </xsl:for-each>
+
+            <system-out>
+              <xsl:call-template name="sysout" />
+            </system-out>
+            <system-err></system-err>
+          </testsuite>
+        </xsl:for-each>
+
+      </xsl:for-each>
+    </testsuites>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Reports that will be generated by gtester binary for glib2 unit tests
can be converted with this XSL to junit format.

See:
* https://developer.gnome.org/glib/stable/glib-Testing.html
* https://developer.gnome.org/glib/stable/gtester.html