### PR TITLE
Adding support for BoostTest v3 logs (Boost 1.59)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/types/BoostTest.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/BoostTest.java
@@ -58,7 +58,7 @@ public class BoostTest extends InputMetricXSL {
 
     @Override
     public String[] getInputXsdNameList() {
-        return new String[]{"boosttest-1.4.0.xsd"};
+        return new String[]{"boosttest-1.5.0.xsd"};
     }
 
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -92,6 +92,8 @@ THE SOFTWARE.
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:positiveInteger" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
             <xs:attribute name="assertions_passed" type="xs:integer" use="optional"/>
             <xs:attribute name="assertions_failed" type="xs:integer" use="optional"/>
             <xs:attribute name="expected_failures" type="xs:integer" use="optional"/>
@@ -133,6 +135,8 @@ THE SOFTWARE.
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:positiveInteger" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
             <xs:attribute name="assertions_passed" type="xs:integer" use="optional"/>
             <xs:attribute name="assertions_failed" type="xs:integer" use="optional"/>
             <xs:attribute name="expected_failures" type="xs:integer" use="optional"/>


### PR DESCRIPTION
Pull request for https://issues.jenkins-ci.org/browse/JENKINS-30105 for changed XML report format of Boost.Test (see https://svn.boost.org/trac/boost/ticket/7410). I havn't tested it yet, because I do not have the required build infrastructure. At least, I prefer the change in the XSD this way so that XML reports of older version can be parsed as well.

