### PR TITLE
Fixing support for BoostTest v3 logs (Boost 1.59), support Context

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.2-to-junit-4.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.2-to-junit-4.xsl
@@ -42,6 +42,14 @@ THE SOFTWARE.
         </xsl:if>
     </xsl:template>
 
+    <xsl:template name="testCaseContext">
+        <xsl:for-each select="child::*">
+            <xsl:text> == [Context] </xsl:text>
+            <xsl:value-of select="."/>
+            <xsl:text>&#13;</xsl:text>
+        </xsl:for-each>
+    </xsl:template>
+
     <xsl:template match="/TestLog">
 
         <xsl:element name="testsuite">
@@ -79,7 +87,7 @@ THE SOFTWARE.
                     <xsl:text>[Error] - </xsl:text>
                     <!--<xsl:call-template name="processQuote">-->
                     <!--<xsl:with-param name="string">-->
-                    <!--<xsl:value-of select="$currElt"/>-->
+                    <!--<xsl:value-of select="$currElt/text()"/>-->
                     <!--</xsl:with-param>-->
                     <!--</xsl:call-template>-->
                     <xsl:value-of select="$currElt"/>
@@ -88,6 +96,9 @@ THE SOFTWARE.
                     <xsl:text>&#13;</xsl:text>
                     <xsl:text> == [Line] - </xsl:text><xsl:value-of select="($currElt)/@line"/>
                     <xsl:text>&#13;</xsl:text>
+                    <xsl:for-each select="child::Context">
+                        <xsl:call-template name="testCaseContext"/>
+                    </xsl:for-each>
                 </xsl:when>
 
                 <xsl:when test="$currEltName='FatalError'">
@@ -95,7 +106,7 @@ THE SOFTWARE.
                     <xsl:text>[Exception] - </xsl:text>
                     <xsl:call-template name="processQuote">
                         <xsl:with-param name="string">
-                            <xsl:value-of select="$currElt"/>
+                            <xsl:value-of select="$currElt/text()"/>
                         </xsl:with-param>
                     </xsl:call-template>
                     <xsl:text>&#13;</xsl:text>
@@ -103,6 +114,9 @@ THE SOFTWARE.
                     <xsl:text>&#13;</xsl:text>
                     <xsl:text> == [Line] -</xsl:text><xsl:value-of select="($currElt)/@line"/>
                     <xsl:text>&#13;</xsl:text>
+                    <xsl:for-each select="child::Context">
+                        <xsl:call-template name="testCaseContext"/>
+                    </xsl:for-each>
                 </xsl:when>
 
                 <xsl:when test="$currEltName='Exception'">
@@ -110,11 +124,12 @@ THE SOFTWARE.
                     <xsl:text>[Exception] - </xsl:text>
                     <xsl:call-template name="processQuote">
                         <xsl:with-param name="string">
-                            <xsl:value-of select="$currElt"/>
+                            <xsl:value-of select="$currElt/text()"/>
                         </xsl:with-param>
                     </xsl:call-template>
                     <xsl:choose>
                         <xsl:when test="($currElt)/LastCheckpoint">
+                            <xsl:value-of select="($currElt)/LastCheckpoint/text()"/>
                             <xsl:text>&#13;</xsl:text>
                             <xsl:text> == [File] - </xsl:text><xsl:value-of select="($currElt)/LastCheckpoint/@file"/>
                             <xsl:text>&#13;</xsl:text>
@@ -130,6 +145,9 @@ THE SOFTWARE.
                             <xsl:text>&#13;</xsl:text>
                         </xsl:otherwise>
                     </xsl:choose>
+                    <xsl:for-each select="child::Context">
+                        <xsl:call-template name="testCaseContext"/>
+                    </xsl:for-each>
                 </xsl:when>
 
                 <xsl:when test="$currEltName='Info'"></xsl:when>
@@ -228,7 +246,7 @@ THE SOFTWARE.
                         <xsl:text>[Info] - </xsl:text>
                         <xsl:call-template name="processQuote">
                             <xsl:with-param name="string">
-                                <xsl:value-of select="$currElt"/>
+                                <xsl:value-of select="$currElt/text()"/>
                             </xsl:with-param>
                         </xsl:call-template>
                         <xsl:text>&#13;</xsl:text>
@@ -245,7 +263,7 @@ THE SOFTWARE.
 
                         <xsl:call-template name="processQuote">
                             <xsl:with-param name="string">
-                                <xsl:value-of select="$currElt"/>
+                                <xsl:value-of select="$currElt/text()"/>
                             </xsl:with-param>
                         </xsl:call-template>
                         <xsl:text>&#13;</xsl:text>
@@ -261,7 +279,7 @@ THE SOFTWARE.
                         <xsl:text>[Message] - </xsl:text>
                         <xsl:call-template name="processQuote">
                             <xsl:with-param name="string">
-                                <xsl:value-of select="$currElt"/>
+                                <xsl:value-of select="$currElt/text()"/>
                             </xsl:with-param>
                         </xsl:call-template>
                         <xsl:text>&#13;</xsl:text>
@@ -269,6 +287,10 @@ THE SOFTWARE.
                         <xsl:text>&#13;</xsl:text>
                         <xsl:text> == [Line] - </xsl:text><xsl:value-of select="($currElt)/@line"/>
                         <xsl:text>&#13;</xsl:text>
+                    </xsl:for-each>
+
+                    <xsl:for-each select="child::*/Context">
+                        <xsl:call-template name="testCaseContext"/>
                     </xsl:for-each>
 
                 </xsl:element>
@@ -283,11 +305,12 @@ THE SOFTWARE.
                         <xsl:text>[Exception] - </xsl:text>
                         <xsl:call-template name="processQuote">
                             <xsl:with-param name="string">
-                                <xsl:value-of select="$currElt"/>
+                                <xsl:value-of select="$currElt/text()"/>
                             </xsl:with-param>
                         </xsl:call-template>
                         <xsl:choose>
                             <xsl:when test="($currElt)/LastCheckpoint">
+                                <xsl:value-of select="($currElt)/LastCheckpoint/text()"/>
                                 <xsl:text>&#13;</xsl:text>
                                 <xsl:text> == [File] - </xsl:text><xsl:value-of
                                     select="($currElt)/LastCheckpoint/@file"/>
@@ -307,6 +330,11 @@ THE SOFTWARE.
                         </xsl:choose>
 
                     </xsl:for-each>
+
+                    <xsl:for-each select="child::*/Context">
+                        <xsl:call-template name="testCaseContext"/>
+                    </xsl:for-each>
+
                 </xsl:element>
             </xsl:if>
 

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -23,8 +23,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Frame" type="xs:string" />
+
+    <xs:element name="Context">
+        <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Frame" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="Error">
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
             <xs:attribute name="line" type="xs:integer" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
@@ -32,6 +45,9 @@ THE SOFTWARE.
 
     <xs:element name="FatalError">
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
             <xs:attribute name="line" type="xs:integer" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
@@ -39,6 +55,9 @@ THE SOFTWARE.
 
     <xs:element name="Info">
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
             <xs:attribute name="line" type="xs:integer" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
@@ -64,6 +83,9 @@ THE SOFTWARE.
 
     <xs:element name="Message">
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
             <xs:attribute name="line" type="xs:positiveInteger" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
@@ -71,6 +93,9 @@ THE SOFTWARE.
 
     <xs:element name="Warning">
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
             <xs:attribute name="line" type="xs:positiveInteger" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>


### PR DESCRIPTION
- accept Context/Frame elements
- add single Frame as '== [Context] ...' lines after line number
- only log first text node in first line (there should be exactly one CDATA), don't
  append text from child nodes like Context/Frame
- manually log text node from LastCheckpoint