### PR TITLE
Don't use previousResultStep if it is NOT_BUILT

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -369,7 +369,7 @@ public class XUnitProcessor implements Serializable {
             if (previousResultStep == null) {
                 return curResult;
             }
-            if (previousResultStep.isWorseOrEqualTo(curResult)) {
+            if (previousResultStep != Result.NOT_BUILT && previousResultStep.isWorseOrEqualTo(curResult)) {
                 curResult = previousResultStep;
             }
             return curResult;


### PR DESCRIPTION
For cases when not all modules in a multimodule project build (eg
when doing an incremental build in jenkins), we were marking the
build as NOT_BUILT. Since not running the plugin would not do
that, ignore a previousResultStep of NOT_BUILT to correct
behaviour.