### PR TITLE
Skip log message which spams log output on console

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitConversionService.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitConversionService.java
@@ -69,7 +69,6 @@ public class XUnitConversionService extends XUnitService implements Serializable
             throw new XUnitException("Can't create " + parent);
         }
         File junitTargetFile = new File(parent, JUNIT_FILE_PREFIX + inputFile.hashCode() + JUNIT_FILE_POSTFIX);
-        xUnitLog.infoConsoleLogger("Converting '" + inputFile + "' .");
         try {
 
             if (inputMetric instanceof CustomInputMetric) {


### PR DESCRIPTION
As already described in old issue [JENKINS-7612](https://issues.jenkins-ci.org/browse/JENKINS-7612) we get a couple of hundred of lines of console output in our Jenkins build (basically one line per test class!):

> [xUnit] [INFO] - Converting '/var/buildlocal/jenkins/jobs/gerrit-ci-job/workspace@3/platform/target/test-results/myproject/TEST-com.company.Testcase12345.xml' .

The workarounds mentioned in [JENKINS-7612](https://issues.jenkins-ci.org/browse/JENKINS-7612) didn't work for us (I guess they might have worked for some ancient version) and looking at the code of `XUnitLog.java` its clear that there is no filtering. IMHO this log information provides no value at all so this change removes it to avoid spamming the build output.