### PR TITLE
Added support for checking unstable tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -36,6 +36,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
+import hudson.tasks.junit.CaseResult;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
 import org.apache.tools.ant.DirectoryScanner;
@@ -50,6 +51,9 @@ import org.jenkinsci.plugins.xunit.types.CustomType;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Gregory Boissinot
@@ -59,15 +63,23 @@ public class XUnitProcessor implements Serializable {
     private TestType[] types;
     private XUnitThreshold[] thresholds;
     private int thresholdMode;
+    private boolean shouldFailIfFrequentTest;
+    private String ageFailedTest;
+    private String unstableTests;
+    private String historyBuilds;
     private ExtraConfiguration extraConfiguration;
 
-    public XUnitProcessor(TestType[] types, XUnitThreshold[] thresholds, int thresholdMode, ExtraConfiguration extraConfiguration) {
+    public XUnitProcessor(TestType[] types, XUnitThreshold[] thresholds, int thresholdMode, boolean shouldFailIfFrequentTest, String ageFailedTest, String unstableTests, String historyBuilds, ExtraConfiguration extraConfiguration) {
         this.types = types;
         if (types == null) {
             throw new NullPointerException("The types section is required.");
         }
         this.thresholds = thresholds;
         this.thresholdMode = thresholdMode;
+        this.shouldFailIfFrequentTest = shouldFailIfFrequentTest;
+        this.ageFailedTest = ageFailedTest;
+        this.unstableTests = unstableTests;
+        this.historyBuilds = historyBuilds;
         this.extraConfiguration = extraConfiguration;
     }
 
@@ -105,8 +117,21 @@ public class XUnitProcessor implements Serializable {
             Result result = getBuildStatus(build, xUnitLog);
             if (result != null) {
                 if (!dryRun) {
-                    xUnitLog.infoConsoleLogger("Setting the build status to " + result);
-                    build.setResult(result);
+                    if(result.isWorseThan(Result.SUCCESS)) {
+                        xUnitLog.infoConsoleLogger("Threshold of failed tests was exceeded.");
+                        xUnitLog.infoConsoleLogger("Setting the build status to " + result);
+                        build.setResult(result);
+                    } else {
+                        if(shouldFailIfFrequentTest && isConsecutiveTest(xUnitLog, build)) {
+                            xUnitLog.infoConsoleLogger("Setting the build status to " + Result.UNSTABLE);
+                            build.setResult(Result.UNSTABLE);
+                        } else if (isValid(ageFailedTest) && isValid(historyBuilds) && isValid(historyBuilds) && isRecurrentTest(xUnitLog, build)){
+                            xUnitLog.infoConsoleLogger("Setting the build status to " + Result.UNSTABLE);
+                            build.setResult(Result.UNSTABLE);
+                        }
+                    }
+
+
                 } else {
                     xUnitLog.infoConsoleLogger("Through the xUnit plugin, the build status will be set to " + result.toString());
                 }
@@ -117,6 +142,80 @@ public class XUnitProcessor implements Serializable {
         } catch (XUnitException xe) {
             xUnitLog.errorConsoleLogger("The plugin hasn't been performed correctly: " + xe.getMessage());
             build.setResult(Result.FAILURE);
+            return false;
+        }
+    }
+
+    private boolean isRecurrentTest(XUnitLog xUnitLog, Run<?, ?> build) {
+        List<CaseResult> recurrentTests = new ArrayList<CaseResult>();
+
+        List<CaseResult> failedTests = build.getAction(TestResultAction.class).getFailedTests();
+        if(failedTests.size() == 0) {
+            xUnitLog.infoConsoleLogger("There are no failed tests.");
+            return false;
+        }
+
+        xUnitLog.infoConsoleLogger("Current build number is " + build.getNumber());
+
+        for (CaseResult currentFailedTest : failedTests) {
+            xUnitLog.infoConsoleLogger("Checking test on " + historyBuilds + " builds \t\t" + currentFailedTest.getSimpleName() + "#" + currentFailedTest.getName());
+            int numberOfFails = numberOfFails(xUnitLog, currentFailedTest, build);
+            if (numberOfFails >= convertToInteger(ageFailedTest)) {
+                xUnitLog.infoConsoleLogger("Recurring test found (" + numberOfFails + "/" + historyBuilds + ").\t\t" + currentFailedTest.getSimpleName() + "#" + currentFailedTest.getName());
+                recurrentTests.add(currentFailedTest);
+            }
+        }
+
+        if (recurrentTests.size() >= convertToInteger(unstableTests)) {
+            xUnitLog.warningConsoleLogger("There are " + recurrentTests.size() + " recurring tests:");
+            for (CaseResult caseResult : recurrentTests) {
+                xUnitLog.warningConsoleLogger(caseResult.getSimpleName() + "#" + caseResult.getName());
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private int numberOfFails(XUnitLog xUnitLog, CaseResult currentFailedTest, Run<?, ?> build) {
+        List<? extends Run<?, ?>> previousBuilds = build.getPreviousBuildsOverThreshold(convertToInteger(historyBuilds), Result.FAILURE);
+        int count = 0;
+        for (Run r : previousBuilds) {
+            TestResultAction previousTestAction = r.getAction(TestResultAction.class);
+            if(previousTestAction != null) {
+                boolean hasFailedOnBuild = false;
+                for (CaseResult previousFailedTest : previousTestAction.getFailedTests()) {
+                    if (currentFailedTest.compareTo(previousFailedTest) == 0) {
+                        hasFailedOnBuild = true;
+                        count++;
+                    }
+                }
+                if (hasFailedOnBuild) {
+                    xUnitLog.infoConsoleLogger("Build #" + r.getNumber() + ".\t Test failed.");
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private boolean isConsecutiveTest(XUnitLog xUnitLog, Run<?, ?> build) {
+        List<CaseResult> testsExceededAge = new ArrayList<CaseResult>();
+
+        TestResultAction testResultAction = getTestResultAction(build);
+        List<CaseResult> failedTests = testResultAction.getFailedTests();
+        for (CaseResult caseResult : failedTests) {
+            if (caseResult.getAge() > 1) {
+                testsExceededAge.add(caseResult);
+            }
+        }
+
+        if (!testsExceededAge.isEmpty()) {
+            for (CaseResult caseResult : testsExceededAge) {
+                xUnitLog.warningConsoleLogger("Test '" + caseResult.getFullDisplayName() + "' failed consecutive and has age " + caseResult.getAge());
+            }
+            return true;
+        } else {
             return false;
         }
     }
@@ -432,4 +531,25 @@ public class XUnitProcessor implements Serializable {
         }
     }
 
+    private boolean isValid(String value) {
+        if (value == null) {
+            return false;
+        }
+
+        if (value.trim().length() == 0) {
+            return false;
+        }
+
+        try {
+            Integer.parseInt(value);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private int convertToInteger(String value) {
+        return Integer.parseInt(value);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author Gregory Boissinot

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -36,6 +36,9 @@ THE SOFTWARE.
         <j:if test="${listXUnitThresholdInstance.size() == 0}">
             <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
         </j:if>
+        <j:if test="${listXUnitThresholdInstance.size() == 0}">
+                    <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
+                </j:if>
         <u:hetero-list-readonly name="thresholds" descriptors="${descriptor.listXUnitThresholdDescriptors}"
                                 items="${listXUnitThresholdInstance}"/>
 
@@ -48,6 +51,43 @@ THE SOFTWARE.
                 <br/>
                 <f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
                 <label class="attach-previous">Use a percent of tests</label>
+            </f:entry>
+            <f:entry title="${%Unstable if test has failed on previous build?}">
+              <f:checkbox name="shouldFailIfFrequentTest" checked="${instance.shouldFailIfFrequentTest}"/>
+            </f:entry>
+            <f:entry field="historyMode" title="${%Define history threshold}">
+              <table width="50%" border='0' cellspacing='0' padding="0">
+              <thead>
+                <tr>
+                  <td>
+                    <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                    ${%Max age for a failed test}
+                  </td>
+                  <td>
+                    <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                    ${%Max number of unstable tests}
+                  </td>
+                  <td>
+                    <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                    ${%Number of history builds}
+                  </td>
+                </tr>
+              </thead>
+
+              <tbody>
+                <tr>
+                  <td>
+                    <f:textbox field="ageFailedTest"/>
+                  </td>
+                  <td>
+                    <f:textbox field="unstableTests"/>
+                  </td>
+                  <td>
+                    <f:textbox field="historyBuilds"/>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
             </f:entry>
         </f:advanced>
 

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -52,10 +52,10 @@ THE SOFTWARE.
                 <f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
                 <label class="attach-previous">Use a percent of tests</label>
             </f:entry>
-            <f:entry title="${%Unstable if test has failed on previous build?}">
+            <f:entry title="${%Fails on consecutive test}">
               <f:checkbox name="shouldFailIfFrequentTest" checked="${instance.shouldFailIfFrequentTest}"/>
             </f:entry>
-            <f:entry field="historyMode" title="${%Define history threshold}">
+            <f:entry field="historyMode" title="${%Thresholds for recurrent tests}">
               <table width="50%" border='0' cellspacing='0' padding="0">
               <thead>
                 <tr>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -49,10 +49,10 @@ THE SOFTWARE.
                 <f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
                 <label class="attach-previous">Use a percent of tests</label>
             </f:entry>
-            <f:entry title="${%Unstable if test has failed on previous build?}">
+            <f:entry title="${%Fails on consecutive test}">
               <f:checkbox name="shouldFailIfFrequentTest" checked="${instance.shouldFailIfFrequentTest}"/>
             </f:entry>
-            <f:entry field="historyMode" title="${%Define history threshold}">
+            <f:entry field="historyMode" title="${%Thresholds for recurrent tests}">
                 <table width="50%" border='0' cellspacing='0' padding="0">
                     <thead>
                         <tr>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -49,6 +49,43 @@ THE SOFTWARE.
                 <f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
                 <label class="attach-previous">Use a percent of tests</label>
             </f:entry>
+            <f:entry title="${%Unstable if test has failed on previous build?}">
+              <f:checkbox name="shouldFailIfFrequentTest" checked="${instance.shouldFailIfFrequentTest}"/>
+            </f:entry>
+            <f:entry field="historyMode" title="${%Define history threshold}">
+                <table width="50%" border='0' cellspacing='0' padding="0">
+                    <thead>
+                        <tr>
+                            <td>
+                                <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                                ${%Max age for a failed test}
+                            </td>
+                            <td>
+                                <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                                ${%Max number of unstable tests}
+                            </td>
+                            <td>
+                                <img src="${rootURL}/images/16x16/yellow.gif" alt="100%"/>
+                                ${%Number of history builds}
+                            </td>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td>
+                                <f:textbox name="ageFailedTest" field="ageFailedTest"/>
+                            </td>
+                            <td>
+                                <f:textbox name="unstableTests" field="unstableTests"/>
+                            </td>
+                            <td>
+                                <f:textbox name="historyBuilds" field="historyBuilds"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </f:entry>
         </f:advanced>
 
     </f:block>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/threshold/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/threshold/Messages.properties
@@ -30,3 +30,4 @@ failureNewThreshold.skippedTests=If the total number of skipped tests exceeds th
 thresholdHelpMessage.skippedTests=Configure the build status. A build is considered as unstable or failure \
 					if the new or total number of skipped tests exceeds the specified thresholds. \
 
+displayName.falsePositive=Unstable by recurrent fails thresholds


### PR DESCRIPTION
Hi everyone.

I'd like to contribute to your plugin with our small feature. Basically, we have a lot of unit, integration and system tests and some tests fail randomly and we'd like to ignore them if these test are not recurring.

The configuration for the feature is available in advanced section and is composed by several parts:
- _Unstable if test has failed on previous build?_. This serves to detect frequent tests. Basically if on run 10 test A failed and on the previous run (for example 9) this test has also failed the build is marked as unstable.
- _Define history threshold_. This features allows to detect how many time tests have failed on the last builds and decide if the build should be marked as unstable or not. These parameters are:
         1. _Number of history builds_. Defines how many build will be used as a history information.
         2. _Max age for a failed test_. Defines how many times the test should fail on the history build to assume it as recurring test.
         3. _Max number of unstable tests_. Defines the threshold for recurring tests.

I don't know if this feature make sense for you but I'd like to discuss this with you.