### PR TITLE
Proof-of-concept for logging level setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
@@ -26,17 +26,26 @@ package org.jenkinsci.plugins.xunit;
 
 import java.io.Serializable;
 
+import com.google.inject.Inject;
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
+
 /**
  * @author Gregory Boissinot
  */
 public class ExtraConfiguration implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final long testTimeMargin;
+    private final XUnitLog.Level logLevel;
 
-    public ExtraConfiguration(long testTimeMargin) {
+    public ExtraConfiguration(long testTimeMargin, XUnitLog.Level logLevel) {
         this.testTimeMargin = testTimeMargin;
+        this.logLevel = logLevel;
+    }
+
+    public XUnitLog.Level getLogLevel() {
+        return logLevel;
     }
 
     public long getTestTimeMargin() {

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
@@ -39,6 +39,7 @@ import hudson.tasks.Builder;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.jenkinsci.plugins.xunit.threshold.FailedThreshold;
 import org.jenkinsci.plugins.xunit.threshold.SkippedThreshold;
 import org.jenkinsci.plugins.xunit.threshold.XUnitThreshold;
@@ -69,7 +70,7 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
     }
 
     @DataBoundConstructor
-    public XUnitBuilder(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin) {
+    public XUnitBuilder(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin, String loggingLevel) {
         this.types = tools;
         this.thresholds = thresholds;
         this.thresholdMode = thresholdMode;
@@ -77,7 +78,8 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {
             longTestTimeMargin = Long.parseLong(testTimeMargin);
         }
-        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin);
+        XUnitLog.Level logLevel = XUnitLog.Level.fromString(loggingLevel);
+        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin, logLevel);
     }
 
     /**
@@ -108,7 +110,7 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
 
     public ExtraConfiguration getExtraConfiguration() {
         if (extraConfiguration == null) {
-            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING);
+            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING, XUnitDefaultValues.LOGGING_LEVEL);
         }
         return extraConfiguration;
     }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitDefaultValues.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitDefaultValues.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.xunit;
 
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
+
 /**
  * @author Gregory Boissinot
  */
@@ -34,4 +36,6 @@ public class XUnitDefaultValues {
     public static final int MODE_PERCENT = 2;
 
     public static final int TEST_REPORT_TIME_MARGING = 3000; //default to 3000ms
+
+    public static final XUnitLog.Level LOGGING_LEVEL = XUnitLog.Level.INFO;
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -38,6 +38,7 @@ import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
+import jenkins.model.Jenkins;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.lib.dtkit.model.InputMetric;
@@ -88,15 +89,15 @@ public class XUnitProcessor implements Serializable {
                 continueTestProcessing = performTests(xUnitLog, build, workspace, listener);
             } catch (StopTestProcessingException e) {
                 build.setResult(Result.FAILURE);
-                xUnitLog.infoConsoleLogger("There are errors when processing test results.");
-                xUnitLog.infoConsoleLogger("Skipping tests recording.");
-                xUnitLog.infoConsoleLogger("Stop build.");
+                xUnitLog.errorConsoleLogger("There are errors when processing test results.");
+                xUnitLog.errorConsoleLogger("Skipping tests recording.");
+                xUnitLog.errorConsoleLogger("Stop build.");
                 return true;
             }
 
             if (!continueTestProcessing) {
-                xUnitLog.infoConsoleLogger("There are errors when processing test results.");
-                xUnitLog.infoConsoleLogger("Skipping tests recording.");
+                xUnitLog.warningConsoleLogger("There are errors when processing test results.");
+                xUnitLog.warningConsoleLogger("Skipping tests recording.");
                 return true;
             }
 
@@ -126,6 +127,7 @@ public class XUnitProcessor implements Serializable {
             @Override
             protected void configure() {
                 bind(TaskListener.class).toInstance(listener);
+                bind(ExtraConfiguration.class).toInstance(extraConfiguration);
             }
         }).getInstance(XUnitLog.class);
     }
@@ -188,6 +190,7 @@ public class XUnitProcessor implements Serializable {
             @Override
             protected void configure() {
                 bind(TaskListener.class).toInstance(listener);
+                bind(ExtraConfiguration.class).toInstance(extraConfiguration);
             }
         }).getInstance(XUnitReportProcessorService.class);
     }
@@ -212,6 +215,7 @@ public class XUnitProcessor implements Serializable {
             @Override
             protected void configure() {
                 bind(TaskListener.class).toInstance(listener);
+                bind(ExtraConfiguration.class).toInstance(extraConfiguration);
                 bind(XUnitLog.class).in(Singleton.class);
                 bind(XUnitValidationService.class).in(Singleton.class);
                 bind(XUnitConversionService.class).in(Singleton.class);
@@ -219,7 +223,7 @@ public class XUnitProcessor implements Serializable {
         }).getInstance(inputMetric.getClass());
 
         return new XUnitToolInfo(
-                new FilePath(new File(Hudson.getInstance().getRootDir(), "userContent")),
+                new FilePath(new File(Jenkins.getInstance().getRootDir(), "userContent")),
                 inputMetric,
                 expandedPattern,
                 tool.isSkipNoTestFiles(),
@@ -254,6 +258,7 @@ public class XUnitProcessor implements Serializable {
             @Override
             protected void configure() {
                 bind(TaskListener.class).toInstance(listener);
+                bind(ExtraConfiguration.class).toInstance(extraConfiguration);
                 bind(XUnitToolInfo.class).toInstance(xUnitToolInfo);
                 bind(XUnitValidationService.class).in(Singleton.class);
                 bind(XUnitConversionService.class).in(Singleton.class);

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -45,6 +45,7 @@ import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.lib.dryrun.DryRun;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.jenkinsci.plugins.xunit.threshold.FailedThreshold;
 import org.jenkinsci.plugins.xunit.threshold.SkippedThreshold;
 import org.jenkinsci.plugins.xunit.threshold.XUnitThreshold;
@@ -74,7 +75,7 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
     }
 
     @DataBoundConstructor
-    public XUnitPublisher(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin) {
+    public XUnitPublisher(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin, String loggingLevel) {
         this.types = tools;
         this.thresholds = thresholds;
         this.thresholdMode = thresholdMode;
@@ -82,7 +83,8 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {
             longTestTimeMargin = Long.parseLong(testTimeMargin);
         }
-        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin);
+        XUnitLog.Level logLevel = XUnitLog.Level.fromString(loggingLevel);
+        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin, logLevel);
     }
 
     /**
@@ -113,7 +115,7 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
 
     public ExtraConfiguration getExtraConfiguration() {
         if (extraConfiguration == null) {
-            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING);
+            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING, XUnitDefaultValues.LOGGING_LEVEL);
         }
         return extraConfiguration;
     }

--- a/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorService.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorService.java
@@ -78,7 +78,7 @@ public class XUnitReportProcessorService extends XUnitService implements Seriali
                     + pattern + "' relative to '" + parentPath + "' for the testing framework '" + toolName + "'."
                     + "  Did you enter a pattern relative to the correct directory?"
                     + "  Did you generate the result report(s) for '" + toolName + "'?";
-            xUnitLog.infoConsoleLogger(msg);
+            xUnitLog.warningConsoleLogger(msg);
             infoSystemLogger(msg);
         } else {
             String msg = "[" + toolName + "] - " + xunitFiles.length + " test report file(s) were found with the pattern '"

--- a/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitToolInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitToolInfo.java
@@ -52,8 +52,8 @@ public class XUnitToolInfo implements Serializable {
     private FilePath cusXSLFile;
 
     public XUnitToolInfo(FilePath userContentRoot, InputMetric inputMetric,
-                         String expandedPattern, Boolean skipNoTestFiles, Boolean failIfNotNew,
-                         Boolean deleteOutputFiles, Boolean stopProcessingIfError,
+                         String expandedPattern, boolean skipNoTestFiles, boolean failIfNotNew,
+                         boolean deleteOutputFiles, boolean stopProcessingIfError,
                          long buildTime, long testTimeMargin, FilePath cusXSLFile) {
         this.userContentRoot = userContentRoot;
         this.inputMetric = inputMetric;

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -74,6 +74,12 @@ THE SOFTWARE.
                         <td width="50%" style="${td}"/>
                     </tr>
                 </table>
+                <label>Set xUnit logging level. INFO prints all messages, WARN skips for example messages about each and every file converted</label>
+                <select name="loggingLevel" value="${instance.extraConfiguration.testTimeMargin}">
+                    <option value="INFO">INFO</option>
+                    <option value="ERROR">WARN</option>
+                    <option value="ERROR">ERROR</option>
+                </select>
             </f:entry>
         </f:advanced>
     </f:block>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -74,6 +74,13 @@ THE SOFTWARE.
                         <td width="50%" style="${td}"/>
                     </tr>
                 </table>
+                <label>Set xUnit logging level. INFO prints all messages, WARN skips for example messages about each and every file converted</label>
+                <select name="loggingLevel" value="${instance.extraConfiguration.testTimeMargin}">
+                    <option value="INFO">INFO</option>
+                    <option value="ERROR">WARN</option>
+                    <option value="ERROR">ERROR</option>
+                </select>
+
             </f:entry>
         </f:advanced>
     </f:block>

--- a/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorServiceTest.java
@@ -11,6 +11,7 @@ import org.jenkinsci.lib.dtkit.model.InputMetricXSL;
 import org.jenkinsci.lib.dtkit.model.InputType;
 import org.jenkinsci.lib.dtkit.model.OutputMetric;
 import org.jenkinsci.lib.dtkit.type.TestType;
+import org.jenkinsci.plugins.xunit.ExtraConfiguration;
 import org.jenkinsci.plugins.xunit.types.model.JUnitModel;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -94,11 +95,15 @@ public class XUnitReportProcessorServiceTest {
     public static void init() {
         final TaskListener listenerMock = mock(TaskListener.class);
         when(listenerMock.getLogger()).thenReturn(new PrintStream(new ByteArrayOutputStream()));
+
+        final ExtraConfiguration extraConfigurationMock = mock(ExtraConfiguration.class);
+        when(extraConfigurationMock.getLogLevel()).thenReturn(XUnitLog.Level.INFO);
         xUnitReportProcessorService = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
                 bind(XUnitLog.class).in(Singleton.class);
                 bind(TaskListener.class).toInstance(listenerMock);
+                bind(ExtraConfiguration.class).toInstance(extraConfigurationMock);
             }
         }).getInstance(XUnitReportProcessorService.class);
 

--- a/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitTransformerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitTransformerTest.java
@@ -9,6 +9,7 @@ import org.jenkinsci.lib.dtkit.model.InputMetricType;
 import org.jenkinsci.lib.dtkit.model.InputMetricXSL;
 import org.jenkinsci.lib.dtkit.model.InputType;
 import org.jenkinsci.lib.dtkit.model.OutputMetric;
+import org.jenkinsci.plugins.xunit.ExtraConfiguration;
 import org.jenkinsci.plugins.xunit.NoFoundTestException;
 import org.jenkinsci.plugins.xunit.types.model.JUnitModel;
 import org.junit.Assert;
@@ -48,6 +49,10 @@ public class XUnitTransformerTest {
     @SuppressWarnings("unused")
     private XUnitToolInfo xUnitToolInfoMock;
 
+    @Mock
+    @SuppressWarnings("unused")
+    private ExtraConfiguration extraConfiguration;
+
     @Rule
     public TempWorkspace tempWorkspace = new TempWorkspace();
 
@@ -60,6 +65,7 @@ public class XUnitTransformerTest {
 
         when(buildListenerMock.getLogger()).thenReturn(new PrintStream(new ByteArrayOutputStream()));
         when(xUnitToolInfoMock.getInputMetric()).thenReturn(new MyInputMetric());
+        when(extraConfiguration.getLogLevel()).thenReturn(XUnitLog.Level.INFO);
 
         xUnitTransformer = Guice.createInjector(Stage.DEVELOPMENT, new AbstractModule() {
             @Override
@@ -69,6 +75,7 @@ public class XUnitTransformerTest {
                 bind(XUnitConversionService.class).toInstance(xUnitConversionServiceMock);
                 bind(XUnitValidationService.class).toInstance(xUnitValidationServiceMock);
                 bind(XUnitReportProcessorService.class).toInstance(xUnitReportProcessorServiceMock);
+                bind(ExtraConfiguration.class).toInstance(extraConfiguration);
             }
         }).getInstance(XUnitTransformer.class);
 


### PR DESCRIPTION
Hi!

We're using xUnit to convert various test results into Jenkins reported results. However, with thousands of results, we get thousands of lines stating `[xUnit] [INFO] - Converting 'foo/bar'` which seems unnecessary in most of the cases.

As this logging did not seem configurable, I tried to make it so. This pull request consists of three changes:
1. Use https instead of http for maven repository (unrelated).
2. Make `XUnitLog#infoConsoleLogger/errorConsoleLogger/warningConsoleLogger` work differently based on selected log level
3. Change some of the calls to `XUnitLog#infoConsoleLogger` to use more severe levels

As this is my first time working with Jenkins plugins and Guice, the approach may be more complex than necessary.
