### PR TITLE
Ensure testuite time attribute is valid for NUnit

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/nunit-1.0-to-junit-2.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/nunit-1.0-to-junit-2.xsl
@@ -53,9 +53,15 @@ THE SOFTWARE.
                     <!--  <redirect:write file="{$outputpath}/TEST-{$assembly}.xml">-->
 
                     <testsuite name="{$assembly}"
-                               tests="{count(*/test-case)}" time="{@time}"
+                               tests="{count(*/test-case)}"
                                failures="{count(*/test-case/failure)}" errors="0"
-                               skipped="{count(*/test-case[@executed='False'])}">
+                               skipped="{count(*/test-case[@executed='False'])}"
+							   >
+					   <xsl:if test="@time!=''">
+							<xsl:attribute name="time">
+								<xsl:value-of select="@time"/>
+							</xsl:attribute>
+						</xsl:if>
                         <xsl:for-each select="*/test-case">
                             <xsl:variable name="testcaseName">
                                 <xsl:choose>


### PR DESCRIPTION
Related to JENKINS-21234

Problem description:
The XSL transformation assumes that all testsuite elements have a valid time attribute. However, if all testcases inside a testfixture are skipped, there is no time information.

This results in ```<testsuite name="FooBar" tests="2" failures="0" errors="0" skipped="2" time="">``` which causes the JUnit parser to reject the file.
With the proposed fix, we instead generate ```<testsuite name="FooBar" tests="2" failures="0" errors="0" skipped="2">``` and the JUnit import is ok.
