### PR TITLE
Tolerate parsing errors when validating Junit XML

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,3 @@
+inherited: true
+owners:
+- devtools-team@criteo.com

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitInputMetric.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitInputMetric.java
@@ -28,9 +28,11 @@ import hudson.FilePath;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.lib.dtkit.model.InputMetricOther;
 import org.jenkinsci.lib.dtkit.util.converter.ConversionException;
+import org.jenkinsci.lib.dtkit.util.validator.ErrorType;
 import org.jenkinsci.lib.dtkit.util.validator.ValidationError;
 import org.jenkinsci.lib.dtkit.util.validator.ValidationException;
 import org.jenkinsci.plugins.xunit.types.model.JUnit10;
+import org.xml.sax.SAXParseException;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,14 +61,27 @@ public class JUnitInputMetric extends InputMetricOther {
         }
     }
 
+    /**
+     * Consider the file as invalid only if there is a fatal error, i.e. if is
+     * not possible for the application to process the document through to the end.
+     *
+     * @param inputXMLFile
+     * @return a boolean
+     * @throws ValidationException
+     * @see org.xml.sax.ErrorHandler#fatalError(SAXParseException)
+     */
     @Override
     public boolean validateInputFile(File inputXMLFile) throws ValidationException {
         final JUnit10 jUnit = new JUnit10();
         List<ValidationError> errors = jUnit.validate(inputXMLFile);
+        boolean isValid = true;
         for (ValidationError error : errors) {
-            System.out.println(error);
+            System.out.println(error + " type: " + error.getType());
+            if (error.getType() == ErrorType.FATAL_ERROR) {
+                isValid = false;
+            }
         }
-        return errors.isEmpty();
+        return isValid;
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/JUnitTypeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/JUnitTypeTest.java
@@ -26,4 +26,10 @@ public class JUnitTypeTest extends AbstractTest {
     public void testTestCase4() throws Exception {
         convertAndValidate(JUnitInputMetric.class, "junit/testcase4/input.xml", "junit/testcase4/input.xml");
     }
+
+    @Test
+    public void testTestCaseXMLParsingErrors() throws Exception {
+        convertAndValidate(JUnitInputMetric.class, "junit/testcase5/input.xml", "junit/testcase5/input.xml");
+    }
+
 }

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/junit/testcase5/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/junit/testcase5/input.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 'schemaLocation' generates a SAX warning -->
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd"
+           name="com.example.ComplexTest"
+           time="0.07" tests="1" errors="0" skipped="0" failures="0">
+    <properties>
+        <!-- 'property' generates a SAX error -->
+        <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"> </property>
+    </properties>
+    <testcase name="shouldNotFail" classname="com.example.ComplexTest" time="0.06"/>
+</testsuite>


### PR DESCRIPTION
According to the org.xml.sax.ErrorHandler documentation, only 'fatal
errors' should prevent the whole processing of XML documents. Simple
'errors' shall not prevent the processing of the document.

The xUnit plugin comes at a late stage. It should attempt to make its best
to interprete the test reports and not be more restrictive than other
*unit plugins for instance.

Thanks to this commit, Junit reports from scalatest 2.2.6 or 3.0.0RC4
will now be considered as valid for instance.

Change-Id: I39f839f299fa77c2af7516a1994672dc1513dfbc
