### PR TITLE
Relax BoostTest line validation

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -86,7 +86,7 @@ THE SOFTWARE.
             <xs:sequence>
                 <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
-            <xs:attribute name="line" type="xs:positiveInteger" use="required"/>
+            <xs:attribute name="line" type="xs:integer" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
@@ -96,7 +96,7 @@ THE SOFTWARE.
             <xs:sequence>
                 <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
-            <xs:attribute name="line" type="xs:positiveInteger" use="required"/>
+            <xs:attribute name="line" type="xs:integer" use="required"/>
             <xs:attribute name="file" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
@@ -117,7 +117,7 @@ THE SOFTWARE.
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
-            <xs:attribute name="line" type="xs:positiveInteger" use="optional"/>
+            <xs:attribute name="line" type="xs:integer" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>
             <xs:attribute name="assertions_passed" type="xs:integer" use="optional"/>
             <xs:attribute name="assertions_failed" type="xs:integer" use="optional"/>
@@ -160,7 +160,7 @@ THE SOFTWARE.
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
-            <xs:attribute name="line" type="xs:positiveInteger" use="optional"/>
+            <xs:attribute name="line" type="xs:integer" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>
             <xs:attribute name="assertions_passed" type="xs:integer" use="optional"/>
             <xs:attribute name="assertions_failed" type="xs:integer" use="optional"/>

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
@@ -98,4 +98,9 @@ public class BoostTestTest extends AbstractTest {
     public void testTestCase17() throws Exception {
         convertAndValidate(BoostTest.class, "boosttest/testcase17/testlog.xml", "boosttest/testcase17/junit-result.xml");
     }
+
+    @Test
+    public void testTestCase18() throws Exception {
+        convertAndValidate(BoostTest.class, "boosttest/testcase18/testlog.xml", "boosttest/testcase18/junit-result.xml");
+    }
 }

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase18/junit-result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase18/junit-result.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="1" errors="0" failures="0" name="MergedTestSuite" skipped="0">
+    <testcase classname="TestSuite" name="TestCase" time="0.000001">
+    </testcase>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase18/testlog.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase18/testlog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestLog>
+   <TestSuite name="TestSuite">
+      <TestCase name="TestCase" file="TestCase.cpp" line="0">
+         <TestingTime>1</TestingTime>
+      </TestCase>
+   </TestSuite>
+</TestLog>


### PR DESCRIPTION
Currently, the BoostTest XML schema definition requires line numbers to
be positive integers. However, we see cases where Boost Test 1.60
generates a test log with line number set to zero. While this is
arguably a Boost Test problem, there's no reason to fail validation and
potentially the whole test run in Jenkins.

Signed-off-by: Pekka Enberg <penberg@iki.fi>