### PR TITLE
[FIX JENKINS-28471] xUnit should compare test results to last build with recorded tests for the "new" thresholds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -268,7 +268,7 @@ public class XUnitProcessor implements Serializable {
     }
 
     private TestResultAction getPreviousTestResultAction(Run<?, ?> build) {
-        Run previousBuild = build.getPreviousBuild();
+        Run previousBuild = build.getPreviousCompletedBuild();
         if (previousBuild == null) {
             return null;
         }


### PR DESCRIPTION
Right now there is a race condition in xUnitPlugin. It tries to get Action from previous build, even this job was not completed. And receives `null` instead of action. After that it converts this `null` value to `0` (https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java#L51). 

That produces incorrect user experience:
* `build #1` fails with 10 failed tests.
* Users needs more time for investigation he sets `0 new failed tests`.
* `build #2` is on-going.
* `build #3` finished with 10 failed tests. xUnit reads from `build #2` which is still on-going and receives 0 failed tests. 10 is bigger than 0 => Fail the build.