### PR TITLE
[JENKINS-51645] Allow use of test data publishers with xunit supported result types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 
 import javax.annotation.CheckForNull;
 
+import com.google.common.collect.Lists;
+import hudson.tasks.junit.TestDataPublisher;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.jenkinsci.plugins.xunit.threshold.FailedThreshold;
@@ -108,7 +110,7 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
     public void perform(final Run<?, ?> build, FilePath workspace, Launcher launcher, final TaskListener listener)
             throws InterruptedException, IOException {
         XUnitProcessor xUnitProcessor = new XUnitProcessor(getTools(), getThresholds(), getThresholdMode(), getExtraConfiguration());
-        xUnitProcessor.process(build, workspace, listener);
+        xUnitProcessor.process(build, workspace, listener, launcher, Lists.<TestDataPublisher>newArrayList());
     }
 
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -73,6 +73,13 @@ THE SOFTWARE.
                     </tr>
                 </table>
             </f:entry>
+            <j:invokeStatic var="testDataPublisherDescriptors"
+                            className="hudson.tasks.junit.TestDataPublisher" method="all" />
+            <j:if test="${testDataPublisherDescriptors.size() > 0}">
+                <f:entry title="Additional test report features" field="testDataPublishers">
+                    <f:repeatableHeteroProperty field="testDataPublishers" hasHeader="true" oneEach="true"/>
+                </f:entry>
+            </j:if>
         </f:advanced>
     </f:block>
 

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitPublisherTest.java
@@ -24,7 +24,13 @@ THE SOFTWARE.
 package org.jenkinsci.plugins.xunit;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.google.common.collect.Lists;
+import hudson.tasks.junit.TestDataPublisher;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.junit.TestResultAction;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.xunit.threshold.FailedThreshold;
@@ -50,6 +56,11 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import hudson.tasks.junit.TestResultAction;
+
+import javax.annotation.Nonnull;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class XUnitPublisherTest {
 
@@ -78,6 +89,21 @@ public class XUnitPublisherTest {
                     return true;
                 }
             };
+        }
+    }
+
+    public static class SpyDataPublisher extends TestDataPublisher
+    {
+        private boolean isCalled;
+
+        public boolean isCalled() {
+            return this.isCalled;
+        }
+
+        @Override
+        public TestResultAction.Data contributeTestData(Run<?, ?> run, @Nonnull FilePath workspace, Launcher launcher, TaskListener listener, TestResult testResult) throws IOException, InterruptedException {
+            this.isCalled = true;
+            return super.contributeTestData(run, workspace, launcher, listener, testResult);
         }
     }
 
@@ -134,6 +160,28 @@ public class XUnitPublisherTest {
         Assert.assertEquals(5, testResultAction.getTotalCount());
         Assert.assertEquals(2, testResultAction.getFailCount());
         Assert.assertEquals(1, testResultAction.getSkipCount());
+    }
+
+    @LocalData
+    @Issue("JENKINS-51645")
+    @Test
+    public void test_publishers_are_run() throws Exception {
+        FreeStyleProject job = jenkinsRule.jenkins.createProject(FreeStyleProject.class, "JENKINS-51645");
+
+        TestType[] tools = new TestType[] { new GoogleTestType("input.xml", false, false, false, true) };
+
+        XUnitPublisher publisher = new XUnitPublisher(tools, new XUnitThreshold[]{}, 1, "3000");
+
+        SpyDataPublisher dataPublisher = new SpyDataPublisher();
+        List<TestDataPublisher> dataPublishers = new ArrayList<>();
+        dataPublishers.add(dataPublisher);
+
+        publisher.setTestDataPublishers(dataPublishers);
+
+        job.getPublishersList().add(publisher);
+
+        job.scheduleBuild2(0).get();
+        assertThat(dataPublisher.isCalled, is(true));
     }
 
 }

--- a/src/test/resources/org/jenkinsci/plugins/xunit/XUnitPublisherTest/workspace/JENKINS-51645/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/XUnitPublisherTest/workspace/JENKINS-51645/input.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="4" failures="2" disabled="1" errors="0" time="0" name="AllTests">
+    <testsuite name="TestSuite" tests="4" failures="2" disabled="1" errors="0" time="0">
+        <testcase name="Ok_Testcase" status="run" time="0" classname="TestSuite"/>
+        <testcase name="Failing_Testcase" status="run" time="0" classname="TestSuite">
+            <failure message="Value of: false&#x0A;  Actual: false&#x0A;Expected: true" type=""><![CDATA[Test_moca_bl.cpp:271
+Value of: false
+  Actual: false
+Expected: true]]></failure>
+        </testcase>
+        <testcase name="Error_Testcase" status="run" time="0" classname="TestSuite">
+            <failure message="Unknown C++ exception thrown in the test body." type=""><![CDATA[unknown file
+Unknown C++ exception thrown in the test body.]]></failure>
+        </testcase>
+        <testcase name="DISABLED_Testcase" status="notrun" time="0" classname="TestSuite"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
for ex: unitary test claiming