### PR TITLE
Added option to fail the build if no tests were run

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/ExtraConfiguration.java
@@ -35,11 +35,16 @@ public class ExtraConfiguration implements Serializable {
 
     private final long testTimeMargin;
 
-    public ExtraConfiguration(long testTimeMargin) {
+    private final boolean failIfNoTestsRun;
+
+    public ExtraConfiguration(long testTimeMargin, boolean failIfNoTestsRun) {
         this.testTimeMargin = testTimeMargin;
+        this.failIfNoTestsRun = failIfNoTestsRun;
     }
 
     public long getTestTimeMargin() {
         return testTimeMargin;
     }
+
+    public boolean getFailIfNoTestsRun() { return failIfNoTestsRun; }
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
@@ -98,8 +98,8 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
     /**
      * Needed to support Snippet Generator and Workflow properly
      */
-    public String getFailIfNoTestsRun() {
-        return String.valueOf(getExtraConfiguration().getFailIfNoTestsRun());
+    public boolean getFailIfNoTestsRun() {
+        return getExtraConfiguration().getFailIfNoTestsRun();
     }
 
     public TestType[] getTypes() {

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
@@ -69,7 +69,8 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
     }
 
     @DataBoundConstructor
-    public XUnitBuilder(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin) {
+    public XUnitBuilder(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin,
+                        boolean failIfNoTestsRun) {
         this.types = tools;
         this.thresholds = thresholds;
         this.thresholdMode = thresholdMode;
@@ -77,7 +78,7 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {
             longTestTimeMargin = Long.parseLong(testTimeMargin);
         }
-        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin);
+        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin, failIfNoTestsRun);
     }
 
     /**
@@ -94,6 +95,13 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
         return String.valueOf(getExtraConfiguration().getTestTimeMargin());
     }
 
+    /**
+     * Needed to support Snippet Generator and Workflow properly
+     */
+    public String getFailIfNoTestsRun() {
+        return String.valueOf(getExtraConfiguration().getFailIfNoTestsRun());
+    }
+
     public TestType[] getTypes() {
         return types;
     }
@@ -108,7 +116,8 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
 
     public ExtraConfiguration getExtraConfiguration() {
         if (extraConfiguration == null) {
-            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING);
+            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING,
+                    XUnitDefaultValues.FAIL_IF_NO_TEST_RUN);
         }
         return extraConfiguration;
     }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitDefaultValues.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitDefaultValues.java
@@ -34,4 +34,6 @@ public class XUnitDefaultValues {
     public static final int MODE_PERCENT = 2;
 
     public static final int TEST_REPORT_TIME_MARGING = 3000; //default to 3000ms
+
+    public static final boolean FAIL_IF_NO_TEST_RUN = false;
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -296,7 +296,14 @@ public class XUnitProcessor implements Serializable {
             }
 
             if (result.getPassCount() == 0 && result.getFailCount() == 0) {
-                xUnitLog.warningConsoleLogger("All test reports are empty.");
+                String message = "All test reports are empty.";
+                if(extraConfiguration.getFailIfNoTestsRun()){
+                    xUnitLog.errorConsoleLogger(message);
+                    build.setResult(Result.FAILURE);
+                } else {
+                    xUnitLog.warningConsoleLogger(message);
+                }
+
             }
 
             if (existingAction == null) {

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -74,7 +74,8 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
     }
 
     @DataBoundConstructor
-    public XUnitPublisher(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin) {
+    public XUnitPublisher(TestType[] tools, XUnitThreshold[] thresholds, int thresholdMode, String testTimeMargin,
+                          boolean failIfNoTestsRun) {
         this.types = tools;
         this.thresholds = thresholds;
         this.thresholdMode = thresholdMode;
@@ -82,7 +83,7 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {
             longTestTimeMargin = Long.parseLong(testTimeMargin);
         }
-        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin);
+        this.extraConfiguration = new ExtraConfiguration(longTestTimeMargin, failIfNoTestsRun);
     }
 
     /**
@@ -99,6 +100,14 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
         return String.valueOf(getExtraConfiguration().getTestTimeMargin());
     }
 
+    /**
+     * Needed to support Snippet Generator and Workflow properly
+     */
+    public String getFailIfNoTestsRun() {
+        return String.valueOf(getExtraConfiguration().getFailIfNoTestsRun());
+    }
+
+
     public TestType[] getTypes() {
         return types;
     }
@@ -113,7 +122,8 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
 
     public ExtraConfiguration getExtraConfiguration() {
         if (extraConfiguration == null) {
-            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING);
+            extraConfiguration = new ExtraConfiguration(XUnitDefaultValues.TEST_REPORT_TIME_MARGING,
+                    XUnitDefaultValues.FAIL_IF_NO_TEST_RUN);
         }
         return extraConfiguration;
     }

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -103,8 +103,8 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
     /**
      * Needed to support Snippet Generator and Workflow properly
      */
-    public String getFailIfNoTestsRun() {
-        return String.valueOf(getExtraConfiguration().getFailIfNoTestsRun());
+    public boolean getFailIfNoTestsRun() {
+        return getExtraConfiguration().getFailIfNoTestsRun();
     }
 
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitToolInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitToolInfo.java
@@ -106,4 +106,5 @@ public class XUnitToolInfo implements Serializable {
     public long getTestTimeMargin() {
         return testTimeMargin;
     }
+
 }

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -73,6 +73,14 @@ THE SOFTWARE.
                         </td>
                         <td width="50%" style="${td}"/>
                     </tr>
+                    <tr>
+                        <td width="50%" style="${td}">
+                            <f:checkbox name="failIfNoTestsRun" checked="${instance.extraConfiguration.failIfNoTestsRun}" value="${instance.extraConfiguration.failIfNoTestsRun}"/>
+                            <label>Fail the build if not a single test was run.
+                            </label>
+                        </td>
+                        <td width="50%" style="${td}"/>
+                    </tr>
                 </table>
             </f:entry>
         </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -73,6 +73,14 @@ THE SOFTWARE.
                         </td>
                         <td width="50%" style="${td}"/>
                     </tr>
+                    <tr>
+                        <td width="50%" style="${td}">
+                            <f:checkbox name="failIfNoTestsRun" checked="${instance.extraConfiguration.failIfNoTestsRun}" value="${instance.extraConfiguration.failIfNoTestsRun}"/>
+                            <label>Fail the build if not a single test was run.
+                            </label>
+                        </td>
+                        <td width="50%" style="${td}"/>
+                    </tr>
                 </table>
             </f:entry>
         </f:advanced>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/googletest/testcase3/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/googletest/testcase3/input.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="0" failures="0" disabled="0" errors="0" time="0.042" name="AllTests">
+</testsuites>


### PR DESCRIPTION
This will enable an option in the configuration to fail the tests if not a single test was run. 
Also it will output in the log
[xUnit] [ERROR] - All test reports are empty.

The use case for this is the following:
- A job run some unit tests (e.g. GTest) with a filter (--gtest-filter=WhateverSuite.testThatDo*)
- A developer renames the unit tests and these tests fall out of the filter
- The job runs, executes 0 tests and build is SUCCESS even though tests may not pass.

With this PR, the job will fail if there are no tests to run.