### PR TITLE
Fix Jenkins-42031: Message as child of TestSuite

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -157,6 +157,7 @@ THE SOFTWARE.
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="TestCase" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="TestSuite" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="Message" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>


### PR DESCRIPTION
[Jenkins-42031](https://issues.jenkins-ci.org/browse/JENKINS-42031): Add "Message" element as child of a "TestSuite" element. 
