### PR TITLE
JENKINS-33385: Fixed bug where test name is empty when not containing package as well.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet-2.0-to-junit-2.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet-2.0-to-junit-2.xsl
@@ -37,9 +37,9 @@ THE SOFTWARE.
             <xsl:with-param name="delimiter" select="'\'" />
           </xsl:call-template>
         </xsl:variable>
-        
+
         <xsl:variable name="assemblyName" select="substring-before($assemblyFileName,'.DLL')"/>
-        
+
         <xsl:variable name="timeStamp">
           <xsl:value-of select="concat(@run-date, 'T', @run-time)"/>
         </xsl:variable>
@@ -56,7 +56,16 @@ THE SOFTWARE.
 
           <xsl:for-each select="collection/test">
 
-            <xsl:variable name="testMethodName" select="substring(@name, string-length(@type)+2)"/>
+            <xsl:variable name="testMethodName">
+                <xsl:choose>
+                <xsl:when test="contains(@name, '.')">
+                  <xsl:value-of select="substring(@name, string-length(@type)+2)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="@name"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
 
             <testcase classname="{@type}" name="{$testMethodName}" time="{@time}">
 

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/XunitDotNetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/XunitDotNetTest.java
@@ -34,4 +34,9 @@ public class XunitDotNetTest extends AbstractTest {
     public void testSimpleTransformationCase1() throws Exception {
         convertAndValidate(XUnitDotNet.class, "xunitdotnet/xunit-simple.xml", "xunitdotnet/junit-simple.xml");
     }
+
+    @Test
+    public void testWithoutPackageAtName() throws Exception {
+        convertAndValidate(XUnitDotNet.class, "xunitdotnet/xunit-without-package-at-name.xml", "xunitdotnet/junit-without-package-at-name.xml");
+    }
 }

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet/junit-without-package-at-name.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet/junit-without-package-at-name.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+<testsuite name="MyProject.Tests" tests="3" time="0.288" timestamp="2014-12-18T14:34:32" failures="1" errors="0" skipped="1">
+<properties>
+<property name="environment" value="64-bit .NET 4.0.30319.18444 [collection-per-class, parallel]" />
+<property name="test-framework" value="xUnit.net 2.0.0.2785" />
+<property name="config-file" value="C:\Jenkins\jobs\my-project\workspace\MyProject\xunit\xunit.console.exe.Config" />
+</properties>
+<testcase classname="MyProject.Tests.SampleFact" name="SuccessfulTestWithTrait" time="35.5236617" />
+</testsuite>
+</testsuites>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet/xunit-without-package-at-name.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/xunitdotnet/xunit-without-package-at-name.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assemblies>
+  <assembly name="C:\Jenkins\jobs\my-project\workspace\MyProject\MyProject.Tests\bin\Release\MyProject.Tests.DLL" environment="64-bit .NET 4.0.30319.18444 [collection-per-class, parallel]" test-framework="xUnit.net 2.0.0.2785" run-date="2014-12-18" run-time="14:34:32" config-file="C:\Jenkins\jobs\my-project\workspace\MyProject\xunit\xunit.console.exe.Config" total="3" passed="1" failed="1" skipped="1" time="0.288" errors="0">
+    <errors />
+    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for MyProject.Tests.SampleFact" time="35.5236617">
+      <test name="SuccessfulTestWithTrait" type="MyProject.Tests.SampleFact" method="SuccessfulTestWithTrait" time="35.5236617" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="SuccessfulTestWithTrait" />
+          <trait name="Description" value="SomeDescription" />
+        </traits>
+      </test>
+    </collection>
+  </assembly>
+</assemblies>


### PR DESCRIPTION
This fixes JENKINS-33385 where the generated jUnitFile doesn't contain a name for a testcase.
I also added a test for this.