### PR TITLE
Make pipeline readable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.37</version>
+        <version>3.9</version>
     </parent>
 
     <artifactId>xunit</artifactId>
@@ -41,12 +41,12 @@
 
     <properties>
         <dtkit.frmk.version>2.0.0</dtkit.frmk.version>
-        <xerces.version>2.9.1</xerces.version>
         <saxon.version>9.1.0.8</saxon.version>
         <dry.run.version>0.1</dry.run.version>
         <xmlunit.version>1.6</xmlunit.version>
         <mockito.version>2.17.0</mockito.version>
         <jenkins.version>1.651.3</jenkins.version>
+        <java.level>7</java.level>
     </properties>
 
     <repositories>
@@ -63,6 +63,26 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+                <version>1.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>2.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-step-api</artifactId>
+                <version>2.12</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.lib.dtkit</groupId>
@@ -75,7 +95,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.lib.dtkit</groupId>
             <artifactId>dtkit-metrics-util</artifactId>
@@ -87,7 +106,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.lib.dtkit</groupId>
             <artifactId>dtkit-metrics-hudson-api</artifactId>
@@ -100,34 +118,17 @@
             <version>${dry.run.version}</version>
         </dependency>
 
-
-        <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
-            <version>${xmlunit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
             <version>${saxon.version}</version>
         </dependency>
-
         <dependency>
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
             <version>${saxon.version}</version>
             <classifier>s9api</classifier>
         </dependency>
-
         <dependency>
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
@@ -142,12 +143,49 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>1.7</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
+        <!-- dependencies to get pipeline work with Jenkins 1.x -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.32</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <scm>
@@ -157,17 +195,17 @@
     </scm>
 
     <build>
-    	<pluginManagement>
-    		<plugins>
-    			<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>findbugs-maven-plugin</artifactId>
-					<configuration>
-						<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
-					</configuration>
-				</plugin>
-    		</plugins>
-    	</pluginManagement>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <configuration>
+                        <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/xunit/AliasInitializer.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/AliasInitializer.java
@@ -40,10 +40,10 @@ import jenkins.model.Jenkins;
  */
 public class AliasInitializer {
 
-    @Initializer(before = InitMilestone.PLUGINS_STARTED)
-    public static void addAliases() {
+    @Initializer(before = InitMilestone.JOB_LOADED)
+    public static void init(Jenkins jenkins) {
         Items.XSTREAM.alias("xunit", XUnitPublisher.class);
-        DescriptorExtensionList<TestType, TestTypeDescriptor<TestType>> extensionList = Jenkins.getActiveInstance().getDescriptorList(TestType.class);
+        DescriptorExtensionList<TestType, TestTypeDescriptor<TestType>> extensionList = jenkins.getDescriptorList(TestType.class);
         for (Iterator<TestTypeDescriptor<TestType>> it = extensionList.iterator(); it.hasNext(); ) {
             Class<? extends TestType> classType = it.next().clazz;
             String className = getClassName(classType);

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitBuilder.java
@@ -62,15 +62,10 @@ public class XUnitBuilder extends Builder implements SimpleBuildStep {
     private int thresholdMode;
     private ExtraConfiguration extraConfiguration;
 
-    public XUnitBuilder(@CheckForNull TestType[] tools, @CheckForNull XUnitThreshold[] thresholds) {
-        this.types = (tools != null ? Arrays.copyOf(tools, tools.length) : new TestType[0]);
-        this.thresholds = (thresholds != null ? Arrays.copyOf(thresholds, thresholds.length) : new XUnitThreshold[0]);
-        this.thresholdMode = 1;
-    }
-
     @DataBoundConstructor
     public XUnitBuilder(@CheckForNull TestType[] tools, @CheckForNull XUnitThreshold[] thresholds, int thresholdMode, @CheckForNull String testTimeMargin) {
-        this(tools, thresholds);
+        this.types = (tools != null ? Arrays.copyOf(tools, tools.length) : new TestType[0]);
+        this.thresholds = (thresholds != null ? Arrays.copyOf(thresholds, thresholds.length) : new XUnitThreshold[0]);
         this.thresholdMode = thresholdMode;
         long longTestTimeMargin = XUnitDefaultValues.TEST_REPORT_TIME_MARGING;
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 
 import javax.annotation.CheckForNull;
 
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dryrun.DryRun;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
@@ -38,6 +39,8 @@ import org.jenkinsci.plugins.xunit.threshold.SkippedThreshold;
 import org.jenkinsci.plugins.xunit.threshold.XUnitThreshold;
 import org.jenkinsci.plugins.xunit.threshold.XUnitThresholdDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
@@ -70,15 +73,10 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
     private int thresholdMode;
     private ExtraConfiguration extraConfiguration;
 
-    public XUnitPublisher(@CheckForNull TestType[] tools, @CheckForNull XUnitThreshold[] thresholds) {
-        this.types = (tools != null ? Arrays.copyOf(tools, tools.length) : new TestType[0]);
-        this.thresholds = (thresholds != null ? Arrays.copyOf(thresholds, thresholds.length) : new XUnitThreshold[0]);
-        this.thresholdMode = 1;
-    }
-
     @DataBoundConstructor
     public XUnitPublisher(@CheckForNull TestType[] tools, @CheckForNull XUnitThreshold[] thresholds, int thresholdMode, @CheckForNull String testTimeMargin) {
-        this(tools, thresholds);
+        this.types = (tools != null ? Arrays.copyOf(tools, tools.length) : new TestType[0]);
+        this.thresholds = (thresholds != null ? Arrays.copyOf(thresholds, thresholds.length) : new XUnitThreshold[0]);
         this.thresholdMode = thresholdMode;
         long longTestTimeMargin = XUnitDefaultValues.TEST_REPORT_TIME_MARGING;
         if (testTimeMargin != null && testTimeMargin.trim().length() != 0) {
@@ -151,12 +149,12 @@ public class XUnitPublisher extends Recorder implements DryRun, Serializable, Si
         return true;
     }
 
-
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
 
+    @Symbol("xunit")
     @Extension
     public static final class XUnitDescriptorPublisher extends BuildStepDescriptor<Publisher> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitUtil.java
@@ -1,0 +1,55 @@
+/*
+* The MIT License (MIT)
+*
+* Copyright (c) 2018, Falco Nikolas
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+package org.jenkinsci.plugins.xunit;
+
+import hudson.Util;
+
+/* package */ final class XUnitUtil {
+
+    private XUnitUtil() {
+    }
+
+    /**
+     * Parses the string argument as a signed decimal {@code long}. In case the
+     * given value is empty or null, the default value is returned.
+     * 
+     * @param value
+     *            to parse
+     * @param defaultValue
+     *            in case argument is not valid or empty or null
+     * @return the {@code long} represented by the argument in decimal,
+     *         otherwise default value if argument is null, empty or invalid.
+     */
+    public static long parsePositiveLong(String value, long defaultValue) {
+        long result = defaultValue;
+        if (Util.fixEmptyAndTrim(value) != null) {
+            try {
+                result = Math.abs(Long.parseLong(value));
+            } catch (NumberFormatException e) {
+                // leave result valued with default value
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
@@ -24,23 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.junit.TestResultAction;
-import org.jenkinsci.plugins.xunit.service.XUnitLog;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * @author Gregory Boissinot
  */
 public class FailedThreshold extends XUnitThreshold {
 
-    public FailedThreshold() {
-    }
-
     @DataBoundConstructor
-    public FailedThreshold(String unstableThreshold, String unstableNewThreshold, String failureThreshold, String failureNewThreshold) {
-        super(unstableThreshold, unstableNewThreshold, failureThreshold, failureNewThreshold);
+    public FailedThreshold() {
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThresholdDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThresholdDescriptor.java
@@ -24,11 +24,14 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import org.jenkinsci.Symbol;
+
 import hudson.Extension;
 
 /**
  * @author Gregory Boissinot
  */
+@Symbol("failed")
 @Extension
 public class FailedThresholdDescriptor extends XUnitThresholdDescriptor<FailedThreshold> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
@@ -24,23 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import org.jenkinsci.plugins.xunit.service.XUnitLog;
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.junit.TestResultAction;
-import org.jenkinsci.plugins.xunit.service.XUnitLog;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * @author Gregory Boissinot
  */
 public class SkippedThreshold extends XUnitThreshold {
 
-    public SkippedThreshold() {
-    }
-
     @DataBoundConstructor
-    public SkippedThreshold(String unstableThreshold, String unstableNewThreshold, String failureThreshold, String failureNewThreshold) {
-        super(unstableThreshold, unstableNewThreshold, failureThreshold, failureNewThreshold);
+    public SkippedThreshold() {
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThresholdDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThresholdDescriptor.java
@@ -24,11 +24,14 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import org.jenkinsci.Symbol;
+
 import hudson.Extension;
 
 /**
  * @author Gregory Boissinot
  */
+@Symbol("skipped")
 @Extension
 public class SkippedThresholdDescriptor extends XUnitThresholdDescriptor<SkippedThreshold> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
@@ -27,9 +27,11 @@ package org.jenkinsci.plugins.xunit.threshold;
 import java.io.Serializable;
 
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Result;
@@ -43,21 +45,18 @@ import jenkins.model.Jenkins;
 public abstract class XUnitThreshold implements ExtensionPoint, Serializable, Describable<XUnitThreshold> {
 
     private String unstableThreshold;
-
     private String unstableNewThreshold;
-
     private String failureThreshold;
-
     private String failureNewThreshold;
 
     protected XUnitThreshold() {
     }
 
     public XUnitThreshold(String unstableThreshold, String unstableNewThreshold, String failureThreshold, String failureNewThreshold) {
-        this.unstableThreshold = unstableThreshold;
-        this.unstableNewThreshold = unstableNewThreshold;
-        this.failureThreshold = failureThreshold;
-        this.failureNewThreshold = failureNewThreshold;
+        this.setUnstableThreshold(unstableThreshold);
+        this.setUnstableNewThreshold(unstableNewThreshold);
+        this.setFailureThreshold(failureThreshold);
+        this.setFailureNewThreshold(failureNewThreshold);
     }
 
     @SuppressWarnings("unchecked")
@@ -74,16 +73,36 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
         return unstableThreshold;
     }
 
+    @DataBoundSetter
+    public void setUnstableThreshold(String unstableThreshold) {
+        this.unstableThreshold = Util.fixEmptyAndTrim(unstableThreshold);
+    }
+
     public String getUnstableNewThreshold() {
         return unstableNewThreshold;
+    }
+
+    @DataBoundSetter
+    public void setUnstableNewThreshold(String unstableNewThreshold) {
+        this.unstableNewThreshold = Util.fixEmptyAndTrim(unstableNewThreshold);
     }
 
     public String getFailureThreshold() {
         return failureThreshold;
     }
 
+    @DataBoundSetter
+    public void setFailureThreshold(String failureThreshold) {
+        this.failureThreshold = Util.fixEmptyAndTrim(failureThreshold);
+    }
+
     public String getFailureNewThreshold() {
         return failureNewThreshold;
+    }
+
+    @DataBoundSetter
+    public void setFailureNewThreshold(String failureNewThreshold) {
+        this.failureNewThreshold = Util.fixEmptyAndTrim(failureNewThreshold);
     }
 
     public abstract Result getResultThresholdNumber(XUnitLog log,
@@ -100,61 +119,58 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
                                            int testCount,
                                            int newTestCount) {
 
-        String thresholdErrorMessage = "The %s number of tests for this category exceeds the specified '%s' threshold value.";
         if (isValid(getFailureThreshold())
                 && (convertToInteger(getFailureThreshold()) < testCount)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "total", "failure"));
+            log.infoConsoleLogger(Messages.XUnitThreshold_thresholdErrorMessage("total", "failure"));
             return Result.FAILURE;
         }
 
         if (isValid(getFailureNewThreshold())
                 && (convertToInteger(getFailureNewThreshold()) < newTestCount)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "new", "new failure"));
+            log.infoConsoleLogger(Messages.XUnitThreshold_thresholdErrorMessage("new", "new failure"));
             return Result.FAILURE;
         }
 
         if (isValid(getUnstableThreshold())
                 && (convertToInteger(getUnstableThreshold()) < testCount)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "total", "unstable"));
+            log.infoConsoleLogger(Messages.XUnitThreshold_thresholdErrorMessage("total", "unstable"));
             return Result.UNSTABLE;
         }
 
         if (isValid(getUnstableNewThreshold())
                 && (convertToInteger(getUnstableNewThreshold()) < newTestCount)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "new", "new unstable"));
+            log.infoConsoleLogger(Messages.XUnitThreshold_thresholdErrorMessage("new", "new unstable"));
             return Result.UNSTABLE;
         }
 
         return Result.SUCCESS;
-
     }
 
     public Result getResultThresholdPercent(XUnitLog log,
                                             double testPercent,
                                             double newTestPercent) {
 
-        String thresholdErrorMessage = "The percent %s tests for this category exceeds the specified '%s' threshold percent value.";
         if (isValid(getFailureThreshold())
-                && (convertToIntegerPercent(getFailureThreshold()) < testPercent)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "of the total number of", "failure"));
+                && (convertToInteger(getFailureThreshold()) < testPercent)) {
+            log.infoConsoleLogger(Messages.XUnitThreshold_percentThresholdErrorMessage("of the total number of", "failure"));
             return Result.FAILURE;
         }
 
         if (isValid(getFailureNewThreshold())
-                && (convertToIntegerPercent(getFailureNewThreshold()) < newTestPercent)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "of the new number of", "new failure"));
+                && (convertToInteger(getFailureNewThreshold()) < newTestPercent)) {
+            log.infoConsoleLogger(Messages.XUnitThreshold_percentThresholdErrorMessage("of the new number of", "new failure"));
             return Result.FAILURE;
         }
 
         if (isValid(getUnstableThreshold())
-                && (convertToIntegerPercent(getUnstableThreshold()) < testPercent)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "of", "unstable"));
+                && (convertToInteger(getUnstableThreshold()) < testPercent)) {
+            log.infoConsoleLogger(Messages.XUnitThreshold_percentThresholdErrorMessage("of", "unstable"));
             return Result.UNSTABLE;
         }
 
         if (isValid(getUnstableNewThreshold())
-                && (convertToIntegerPercent(getUnstableNewThreshold()) < newTestPercent)) {
-            log.infoConsoleLogger(String.format(thresholdErrorMessage, "of the new number of", "new unstable"));
+                && (convertToInteger(getUnstableNewThreshold()) < newTestPercent)) {
+            log.infoConsoleLogger(Messages.XUnitThreshold_percentThresholdErrorMessage("of the new number of", "new unstable"));
             return Result.UNSTABLE;
         }
 
@@ -165,17 +181,8 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
         return Integer.parseInt(threshold);
     }
 
-    private int convertToIntegerPercent(String threshold) {
-        String thresholdRemoved = threshold.replace("%", "");
-        return Integer.parseInt(thresholdRemoved);
-    }
-
     private boolean isValid(String threshold) {
         if (threshold == null) {
-            return false;
-        }
-
-        if (threshold.trim().length() == 0) {
             return false;
         }
 
@@ -187,4 +194,5 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
 
         return true;
     }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThresholdDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThresholdDescriptor.java
@@ -24,8 +24,14 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import javax.annotation.CheckForNull;
+
+import org.kohsuke.stapler.QueryParameter;
+
 import hudson.DescriptorExtensionList;
+import hudson.Util;
 import hudson.model.Descriptor;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 
 /**
@@ -50,5 +56,32 @@ public abstract class XUnitThresholdDescriptor<T extends XUnitThreshold> extends
     public abstract String getFailureNewThresholdImgTitle();
 
     public abstract String getThresholdHelpMessage();
+
+    public FormValidation doCheckUnstableThreshold(@CheckForNull @QueryParameter(fixEmpty = true) final String unstableThreshold) {
+        return validate(unstableThreshold);
+    }
+
+    public FormValidation doCheckUnstableNewThreshold(@CheckForNull @QueryParameter(fixEmpty = true) final String unstableNewThreshold) {
+        return validate(unstableNewThreshold);
+    }
+
+    public FormValidation doCheckFailureThreshold(@CheckForNull @QueryParameter(fixEmpty = true) final String failureThreshold) {
+        return validate(failureThreshold);
+    }
+
+    public FormValidation doCheckFailureNewThreshold(@CheckForNull @QueryParameter(fixEmpty = true) final String failureNewThreshold) {
+        return validate(failureNewThreshold);
+    }
+
+    private FormValidation validate(final String threshold) {
+        if (Util.fixEmptyAndTrim(threshold) != null) {
+            try {
+                Integer.parseInt(threshold);
+            } catch (NumberFormatException e) {
+                return FormValidation.error(Messages.XUnitThresholdDescriptor_checkThreshold(threshold));
+            }
+        }
+        return FormValidation.ok();
+    }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/AUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/AUnitJunitHudsonTestType.java
@@ -24,11 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href=
+ * "http://docs.adacore.com/live/wave/aunit/html/aunit_cb/aunit_cb.html">AUnit</a>
+ * is a unit testing framework of the xUnit family for the Ada language,
+ * originally developed by Ed Falis and maintained by AdaCore, distributed
+ * together with GNAT.
+ */
 public class AUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +45,7 @@ public class AUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("AUnit")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<AUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/BoostTestJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/BoostTestJunitHudsonTestType.java
@@ -24,11 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://www.boost.org/doc/libs/release/libs/test">Boost.Test</a> is a
+ * C++03 and C++11/14 unit testing library, available on a wide range of
+ * platforms and compilers. The library is part of Boost.
+ */
 public class BoostTestJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +43,7 @@ public class BoostTestJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("BoostTest")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<BoostTestJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CTestType.java
@@ -24,12 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="https://cmake.org/Wiki/CMake/Testing_With_CTest">CTest</a> is a
+ * testing tool distributed as a part of CMake. It can be used to automate
+ * updating (using CVS for example), configuring, building, testing, performing
+ * memory checking, performing coverage, and submitting results to a CDash or
+ * Dart dashboard system.
+ * 
  * @author Gregory Boissinot
  */
 public class CTestType extends TestType {
@@ -39,6 +47,7 @@ public class CTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("CTest")
     @Extension
     public static class CTestTypeDescriptor extends TestTypeDescriptor<CTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CUnitJunitHudsonTestType.java
@@ -24,11 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://cunit.sourceforge.net">CUnit</a> is a lightweight system for
+ * writing, administering, and running unit tests in C.
+ * <p>
+ * It provides C programmers a basic testing functionality with a flexible
+ * variety of user interfaces.
+ */
 public class CUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +45,7 @@ public class CUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("CUnit")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<CUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CheckType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CheckType.java
@@ -24,10 +24,12 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
 
 /**
  * @author Gregory Boissinot
@@ -39,6 +41,7 @@ public class CheckType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("Check")
     @Extension
     public static class CheckTypeDescriptor extends TestTypeDescriptor<CheckType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CppTestJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CppTestJunitHudsonTestType.java
@@ -24,11 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://cpptest.sourceforge.net">CppTest</a> is a portable and
+ * powerful, yet simple, unit testing framework for handling automated tests in
+ * C++. The focus lies on usability and extendability.
+ */
 public class CppTestJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +43,7 @@ public class CppTestJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("CppTest")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<CppTestJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CppUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CppUnitJunitHudsonTestType.java
@@ -24,11 +24,22 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://cppunit.sourceforge.net/doc/cvs/index.html">CppUnit</a> is a
+ * unit testing framework module for the C++ programming language.
+ * <p>
+ * The first port of JUnit to C++ was done by Michael Feathers. His versions can
+ * be found on the XProgramming software page. They are os-specific, so Jerome
+ * Lacoste provided a port to Unix/Solaris. His version can be found on the same
+ * page. The CppUnit project has combined and built on this work.
+ */
 public class CppUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +47,7 @@ public class CppUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("CppUnit")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<CppUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/CustomType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/CustomType.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -47,6 +48,7 @@ public class CustomType extends TestType {
         return customXSL;
     }
 
+    @Symbol("Custom")
     @Extension
     public static class CustomInputMetricDescriptor extends TestTypeDescriptor<CustomType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/EmbUnitType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/EmbUnitType.java
@@ -24,12 +24,21 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="http://embunit.sourceforge.net/embunit">Embedded Unit</a> is unit
+ * testing framework for Embedded C System.
+ * <p>
+ * It's design was copied from JUnit and CUnit and more, and then adapted
+ * somewhat for Embedded C System. Embedded Unit does not require std C libs.
+ * All objects are allocated to const area.
+ * 
  * @author Gregory Boissinot
  */
 public class EmbUnitType extends TestType {
@@ -39,6 +48,7 @@ public class EmbUnitType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("embUnit")
     @Extension
     public static class EmbUnitTypeDescriptor extends TestTypeDescriptor<EmbUnitType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/FPCUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/FPCUnitJunitHudsonTestType.java
@@ -24,11 +24,19 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://wiki.freepascal.org/fpcunit">FPCUni</a> is a unit testing
+ * framework a la DUnit/JUnit/SUnit. This allows you to quickly write a set of
+ * test for a (logical) unit of code (not necessarily the same as a Pascal unit,
+ * though often it is).
+ */
 public class FPCUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +44,7 @@ public class FPCUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("FPCUnit")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<FPCUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/GTesterJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/GTesterJunitHudsonTestType.java
@@ -24,11 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="https://developer.gnome.org/glib/stable/gtester.html">gtester</a> is
+ * a utility to run unit tests that have been written using the GLib test
+ * framework.
+ */
 public class GTesterJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +43,7 @@ public class GTesterJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("gtester")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<GTesterJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/GoogleTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/GoogleTestType.java
@@ -24,12 +24,17 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="https://github.com/google/googletest">Google Test</a>, Google's C++
+ * test framework!
+ * 
  * @author David Hallas
  */
 public class GoogleTestType extends TestType {
@@ -39,6 +44,7 @@ public class GoogleTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("GoogleTest")
     @Extension
     public static class GoogleTestTypeDescriptor extends TestTypeDescriptor<GoogleTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/JUnitType.java
@@ -24,12 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="https://junit.org">JUnit</a> is a simple framework to write
+ * repeatable tests. It is an instance of the xUnit architecture for unit
+ * testing frameworks.
+ * 
  * @author Gregory Boissinot
  */
 public class JUnitType extends TestType {
@@ -39,6 +45,7 @@ public class JUnitType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("JUnit")
     @Extension
     public static class JUnitTypeDescriptor extends TestTypeDescriptor<JUnitType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/MSTestJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/MSTestJunitHudsonTestType.java
@@ -24,11 +24,17 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href= "https://github.com/Microsoft/testfx">Microsoft Test Framework and
+ * Adapter</a> it's the testing framework embedded in .NET Core.
+ */
 public class MSTestJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +42,7 @@ public class MSTestJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("MSTest")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<MSTestJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/MbUnitType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/MbUnitType.java
@@ -24,12 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="https://github.com/Gallio/mbunit-v2">MbUnit</a> is an extensible
+ * unit testing framework for the .NET Framework that takes in and goes beyond
+ * xUnit pattern testing. MbUnit is part of the Gallio bundle.
+ * 
  * @author Gregory Boissinot
  */
 public class MbUnitType extends TestType {
@@ -39,6 +45,7 @@ public class MbUnitType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("MbUnit")
     @Extension
     public static class MbUnitTypeDescriptor extends TestTypeDescriptor<MbUnitType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/NUnit3TestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/NUnit3TestType.java
@@ -24,10 +24,12 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
 
 public class NUnit3TestType extends TestType {
 
@@ -36,6 +38,7 @@ public class NUnit3TestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("NUnit3")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<NUnit3TestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/NUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/NUnitJunitHudsonTestType.java
@@ -24,11 +24,17 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://nunit.org">NUnit</a> is a unit-testing framework for all .Net
+ * languages.
+ */
 public class NUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +42,7 @@ public class NUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("NUnit2")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<NUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/PHPUnitJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/PHPUnitJunitHudsonTestType.java
@@ -24,11 +24,18 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="https://phpunit.de">PHPUnit</a> is a programmer-oriented testing
+ * framework for PHP. It is an instance of the xUnit architecture for unit
+ * testing frameworks.
+ */
 public class PHPUnitJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +43,7 @@ public class PHPUnitJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("PHPUnit")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<PHPUnitJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/QTestLibInputMetric.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/QTestLibInputMetric.java
@@ -41,7 +41,7 @@ public class QTestLibInputMetric extends InputMetricXSL {
 
     @Override
     public String getToolVersion() {
-        return "Version N/A";
+        return "Version 5.x";
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/QTestLibType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/QTestLibType.java
@@ -24,12 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
 /**
+ * <a href="http://doc.qt.io/qt-5/qtest-overview.html">Qt Test</a> is a
+ * framework for unit testing Qt based applications and libraries.
+ * <p>
+ * Qt Test provides all the functionality commonly found in unit testing
+ * frameworks as well as extensions for testing graphical user interfaces.
+ * 
  * @author Gregory Boissinot
  */
 public class QTestLibType extends TestType {
@@ -39,6 +47,7 @@ public class QTestLibType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("QtTest")
     @Extension
     public static class QTestLibTypeDescriptor extends TestTypeDescriptor<QTestLibType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/UnitTestJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/UnitTestJunitHudsonTestType.java
@@ -24,10 +24,12 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
 
 public class UnitTestJunitHudsonTestType extends TestType {
 
@@ -36,6 +38,7 @@ public class UnitTestJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("UnitTest")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<UnitTestJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/ValgrindJunitHudsonTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/ValgrindJunitHudsonTestType.java
@@ -24,11 +24,19 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="http://valgrind.org">Valgrind</a> is an instrumentation framework for
+ * building dynamic analysis tools. There are Valgrind tools that can
+ * automatically detect many memory management and threading bugs, and profile
+ * your programs in detail.
+ */
 public class ValgrindJunitHudsonTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +44,7 @@ public class ValgrindJunitHudsonTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("Valgrind")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<ValgrindJunitHudsonTestType> {
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/types/XUnitDotNetTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/XUnitDotNetTestType.java
@@ -24,11 +24,20 @@
 
 package org.jenkinsci.plugins.xunit.types;
 
-import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import hudson.Extension;
+
+/**
+ * <a href="https://xunit.github.io">xUnit.net</a> is a free, open source,
+ * community-focused unit testing tool for the .NET Framework.
+ * <p>
+ * Written by the original inventor of NUnit v2, xUnit.net is the latest
+ * technology for unit testing C#, F#, VB.NET and other .NET languages.
+ */
 public class XUnitDotNetTestType extends TestType {
 
     @DataBoundConstructor
@@ -36,6 +45,7 @@ public class XUnitDotNetTestType extends TestType {
         super(pattern, skipNoTestFiles, failIfNotNew, deleteOutputFiles, stopProcessingIfError);
     }
 
+    @Symbol("xUnitDotNet")
     @Extension
     public static class DescriptorImpl extends TestTypeDescriptor<XUnitDotNetTestType> {
 

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitBuilder/config.jelly
@@ -25,17 +25,15 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:u="/util">
 
     <f:block>
-        <f:hetero-list name="tools" descriptors="${descriptor.listXUnitTypeDescriptors}" items="${instance.types}"/>
+        <f:hetero-list name="tools" descriptors="${descriptor.listXUnitTypeDescriptors}" items="${instance.tools}"/>
     </f:block>
 
     <f:block>
         <j:set var="listXUnitThresholdInstance" value="${instance.thresholds}"/>
-        <j:if test="${listXUnitThresholdInstance == null}">
+        <j:if test="${listXUnitThresholdInstance == null || listXUnitThresholdInstance.size() == 0}">
             <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
         </j:if>
-        <j:if test="${listXUnitThresholdInstance.size() == 0}">
-            <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
-        </j:if>
+
         <u:hetero-list-readonly name="thresholds" descriptors="${descriptor.listXUnitThresholdDescriptors}"
                                 items="${listXUnitThresholdInstance}"/>
 
@@ -65,11 +63,10 @@ THE SOFTWARE.
                 <table width="100%" border='0' cellspacing='0' padding="0">
                     <tr>
                         <td width="50%" style="${td}">
-                            <label>Give the report time margin value (default to 3000) in ms, before to fail if not new
-                                (unless the option 'Fail the build if test results were not updated this run' is
-                                checked).
+                            <label>Give the report time margin value in ms (default to 3000), before to fail if not new
+                                (unless the option 'Fail the build if test results were not updated this run' is checked).
                             </label>
-                            <f:textbox name="testTimeMargin" value="${instance.extraConfiguration.testTimeMargin}"/>
+                            <f:number name="testTimeMargin" value="${instance.extraConfiguration.testTimeMargin}" default="3000"/>
                         </td>
                         <td width="50%" style="${td}"/>
                     </tr>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/XUnitPublisher/config.jelly
@@ -25,17 +25,15 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:u="/util">
 
     <f:block>
-        <f:hetero-list name="tools" descriptors="${descriptor.listXUnitTypeDescriptors}" items="${instance.types}"/>
+        <f:hetero-list name="tools" descriptors="${descriptor.listXUnitTypeDescriptors}" items="${instance.tools}"/>
     </f:block>
 
     <f:block>
         <j:set var="listXUnitThresholdInstance" value="${instance.thresholds}"/>
-        <j:if test="${listXUnitThresholdInstance == null}">
+        <j:if test="${listXUnitThresholdInstance == null || listXUnitThresholdInstance.size() == 0}">
             <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
         </j:if>
-        <j:if test="${listXUnitThresholdInstance.size() == 0}">
-            <j:set var="listXUnitThresholdInstance" value="${descriptor.listXUnitThresholdInstance}"/>
-        </j:if>
+
         <u:hetero-list-readonly name="thresholds" descriptors="${descriptor.listXUnitThresholdDescriptors}"
                                 items="${listXUnitThresholdInstance}"/>
 
@@ -65,11 +63,11 @@ THE SOFTWARE.
                 <table width="100%" border='0' cellspacing='0' padding="0">
                     <tr>
                         <td width="50%" style="${td}">
-                            <label>Give the report time margin value (default to 3000) in ms, before to fail if not new
+                            <label>Give the report time margin value in ms (default to 3000), before to fail if not new
                                 (unless the option 'Fail the build if test results were not updated this run' is
                                 checked).
                             </label>
-                            <f:textbox name="testTimeMargin" value="${instance.extraConfiguration.testTimeMargin}"/>
+                            <f:number name="testTimeMargin" value="${instance.extraConfiguration.testTimeMargin}" default="3000"/>
                         </td>
                         <td width="50%" style="${td}"/>
                     </tr>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/threshold/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/threshold/Messages.properties
@@ -30,3 +30,6 @@ failureNewThreshold.skippedTests=If the total number of skipped tests exceeds th
 thresholdHelpMessage.skippedTests=Configure the build status. A build is considered as unstable or failure \
 					if the new or total number of skipped tests exceeds the specified thresholds. \
 
+XUnitThreshold.thresholdErrorMessage=The {0} number of tests for this category exceeds the specified "{1}" threshold value.
+XUnitThreshold.percentThresholdErrorMessage=The percent {0} tests for this category exceeds the specified "{1}" threshold percent value.
+XUnitThresholdDescriptor.checkThreshold=Invalid threshold format for value: {0}

--- a/src/main/resources/util/hetero-list-readonly.jelly
+++ b/src/main/resources/util/hetero-list-readonly.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
         Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of
         arbitrary items from the given list of descriptors, and configure them independently.
 
-        The submission can be data-bound into List&lt;T> where T is the common base type for the describable instances.
+    The submission can be data-bound into List&lt;T&gt; where T is the common base type for the describable instances.
 
         <st:attribute name="name" use="required">
             form name that receives an array for all the items in the heterogeneous list.

--- a/src/main/resources/util/threshold.jelly
+++ b/src/main/resources/util/threshold.jelly
@@ -74,6 +74,9 @@ THE SOFTWARE.
                         <f:textbox field="failureNewThreshold"/>
                     </td>
                 </tr>
+                <tr class="validation-error-area">
+                    <td width="80" style="vertical-align:middle"></td><td colspan="4"></td>
+                </tr>
             </tbody>
 
         </table>

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitSerialisationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitSerialisationTest.java
@@ -1,0 +1,95 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2018, Falco Nikolas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.jenkinsci.plugins.xunit;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.jenkinsci.lib.dtkit.type.TestType;
+import org.jenkinsci.plugins.xunit.types.JUnitType;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Items;
+import hudson.tasks.Builder;
+import hudson.tasks.Publisher;
+
+public class XUnitSerialisationTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @BeforeClass
+    public static void dirtyXStreamSetup() {
+        // used to simulate the AliasInitializer that is not triggered by the JenkinsRule
+        Items.XSTREAM.alias("xunit", XUnitPublisher.class);
+        Items.XSTREAM.alias(JUnitType.class.getSimpleName(), JUnitType.class);
+    }
+
+    @LocalData("publisher_1_103")
+    @Test
+    public void verify_publisher_compatible_before_1_103() throws Exception {
+        FreeStyleProject project = (FreeStyleProject) r.jenkins.getItem("foo");
+
+        assertThat(project.getPublishersList().size(), is(1));
+
+        Publisher publisher = project.getPublishersList().get(0);
+        assertThat(publisher, instanceOf(XUnitPublisher.class));
+
+        XUnitPublisher xunitPublisher = (XUnitPublisher) publisher;
+        assertThat(xunitPublisher.getTools().length, is(1));
+
+        verifyJUnitTool(xunitPublisher.getTools()[0]);
+    }
+
+    @LocalData("builder_1_103")
+    @Test
+    public void verify_builder_compatible_before_1_103() throws Exception {
+        FreeStyleProject project = (FreeStyleProject) r.jenkins.getItem("foo");
+
+        assertThat(project.getBuildersList().size(), is(1));
+
+        Builder builders = project.getBuildersList().get(0);
+        assertThat(builders, instanceOf(XUnitBuilder.class));
+
+        XUnitBuilder xunitBuilder = (XUnitBuilder) builders;
+        assertThat(xunitBuilder.getTools().length, is(1));
+
+        verifyJUnitTool(xunitBuilder.getTools()[0]);
+    }
+
+    private void verifyJUnitTool(TestType tool) {
+        assertThat(tool, instanceOf(JUnitType.class));
+        assertThat(tool.getPattern(), is("**/target/surefire-reports/*.xml"));
+        assertThat(tool.isDeleteOutputFiles(), is(true));
+        assertThat(tool.isFailIfNotNew(), is(false));
+        assertThat(tool.isSkipNoTestFiles(), is(false));
+        assertThat(tool.isStopProcessingIfError(), is(true));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitWorkflowTest.java
@@ -53,7 +53,7 @@ public class XUnitWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                 + "node {\n"
                 + "  step([$class: 'XUnitBuilder', testTimeMargin: '3000', thresholdMode: 1, thresholds: [[$class: 'FailedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '1'], [$class: 'SkippedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '']], tools: [[$class: 'GoogleTestType', deleteOutputFiles: false, failIfNotNew: false, pattern: 'input.xml', skipNoTestFiles: false, stopProcessingIfError: true]]])\n"
-                + "}"));
+                + "}", true));
 
         jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
     }
@@ -76,8 +76,23 @@ public class XUnitWorkflowTest {
         job.setDefinition(new CpsFlowDefinition(""
                 + "node {\n"
                 + "  step([$class: 'XUnitPublisher', testTimeMargin: '3000', thresholdMode: 1, thresholds: [[$class: 'FailedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '1'], [$class: 'SkippedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '']], tools: [[$class: 'GoogleTestType', deleteOutputFiles: false, failIfNotNew: false, pattern: 'input.xml', skipNoTestFiles: false, stopProcessingIfError: true]]])\n"
-                + "}"));
+                + "}", true));
 
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+    }
+
+    @Test
+    public void xunit() throws Exception {
+        WorkflowJob job = getBaseJob("readablePublisherPipeline");
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + "  xunit(testTimeMargin: '3000',"
+                + "        thresholdMode: 1,"
+                + "        thresholds: [ failed(failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '1') ],"
+                + "        tools: [ GoogleTest(deleteOutputFiles: false, failIfNotNew: false, pattern: 'input.xml', skipNoTestFiles: false, stopProcessingIfError: true) ]"
+                + "  )\n"
+                + "}", true));
+        
         jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitWorkflowTest.java
@@ -88,7 +88,7 @@ public class XUnitWorkflowTest {
                 + "node {\n"
                 + "  xunit(testTimeMargin: '3000',"
                 + "        thresholdMode: 1,"
-                + "        thresholds: [ failed(failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '1') ],"
+                + "        thresholds: [ failed(unstableThreshold: '1'), skipped() ],"
                 + "        tools: [ GoogleTest(deleteOutputFiles: false, failIfNotNew: false, pattern: 'input.xml', skipNoTestFiles: false, stopProcessingIfError: true) ]"
                 + "  )\n"
                 + "}", true));

--- a/src/test/resources/org/jenkinsci/plugins/xunit/XUnitSerialisationTest/builder_1_103/jobs/foo/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/XUnitSerialisationTest/builder_1_103/jobs/foo/config.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+   <org.jenkinsci.plugins.xunit.XUnitBuilder plugin="xunit@1.103">
+      <types>
+        <JUnitType>
+          <pattern>**/target/surefire-reports/*.xml</pattern>
+          <skipNoTestFiles>false</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </types>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold>1</failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold></failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <extraConfiguration>
+        <testTimeMargin>3000</testTimeMargin>
+      </extraConfiguration>
+    </org.jenkinsci.plugins.xunit.XUnitBuilder>
+  </builders>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/XUnitSerialisationTest/publisher_1_103/jobs/foo/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/XUnitSerialisationTest/publisher_1_103/jobs/foo/config.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <publishers>
+    <xunit plugin="xunit@1.103">
+      <types>
+        <JUnitType>
+          <pattern>**/target/surefire-reports/*.xml</pattern>
+          <skipNoTestFiles>false</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </types>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold>1</failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold></failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <extraConfiguration>
+        <testTimeMargin>3000</testTimeMargin>
+      </extraConfiguration>
+    </xunit>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/config.xml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>false</canRoam>
+  <disabled>true</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+   <org.jenkinsci.plugins.xunit.XUnitBuilder plugin="xunit@1.103">
+      <types>
+        <JUnitType>
+          <pattern>**/target/surefire-reports/*.xml</pattern>
+          <skipNoTestFiles>false</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </types>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold>1</failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold></failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <extraConfiguration>
+        <testTimeMargin>3000</testTimeMargin>
+      </extraConfiguration>
+    </org.jenkinsci.plugins.xunit.XUnitBuilder>
+  </builders>
+  <publishers>
+    <xunit plugin="xunit@1.103">
+      <types>
+        <JUnitType>
+          <pattern>**/target/surefire-reports/*.xml</pattern>
+          <skipNoTestFiles>false</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </types>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold>1</failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+          <unstableThreshold></unstableThreshold>
+          <unstableNewThreshold></unstableNewThreshold>
+          <failureThreshold></failureThreshold>
+          <failureNewThreshold></failureNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <extraConfiguration>
+        <testTimeMargin>3000</testTimeMargin>
+      </extraConfiguration>
+    </xunit>
+  </publishers>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
Hi Oleg, could you please give your opinion about the naming convention adopted to be readable pipeline?

- I use **xunit** name for the simple step like a normal plugin does
- For publisher I would mark it with prefix or postfix (better **xunit**Publisher or publishXUnit?)
- On test type I have add two names, but I would keep just one. It's better lowercase test tool name or just use the real tools name (no camel case or other kinds of convention)?

Test case will comes later when naming convention will be approved