### PR TITLE
abort the build to prevent the running of any other build steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import hudson.AbortException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.DirectoryScanner;
@@ -163,6 +164,11 @@ public class XUnitProcessor {
         logger.info("Setting the build status to " + result);
         build.setResult(result);
         logger.info("Stopping recording.");
+
+        if (result == Result.FAILURE) {
+            // abort the build to prevent the running of any other build steps.
+            throw new AbortException("Tests failed.");
+        }
     }
 
     private int processTestsReport(Run<?, ?> build,


### PR DESCRIPTION
Currently (as-of xunit-plugin 2.1.0 and jenkins 2.121.2) the build is not really stopped when there are test failures. This is quite unexpected, as the build steps after the "Process xUnit test result report" build step still merrily run even though the tests failed. This PR will abort the build with an AbortException when there are test failures.