### PR TITLE
Update junit-10.xsd

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -1,19 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License (MIT)
-
 Copyright (c) 2014, Gregory Boissinot
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,166 +19,157 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:simpleType name="SUREFIRE_TIME">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
-        </xs:restriction>
-    </xs:simpleType>
-
-    <xs:element name="failure">
-        <xs:complexType mixed="true">
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="error">
-        <xs:complexType mixed="true">
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="skipped">
-        <xs:complexType mixed="true">
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="properties">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="property">
-        <xs:complexType>
-            <xs:attribute name="name" type="xs:string" use="required"/>
-            <xs:attribute name="value" type="xs:string" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="system-err" type="xs:string"/>
-    <xs:element name="system-out" type="xs:string"/>
-
-    <xs:element name="rerunFailure" nillable="true">
-        <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="system-out" />
-                    <xs:element ref="system-err" />
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="rerunError" nillable="true">
-        <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="system-out" />
-                    <xs:element ref="system-err" />
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="flakyFailure" nillable="true">
-        <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="system-out" />
-                    <xs:element ref="system-err" />
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="flakyError" nillable="true">
-        <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="system-out" />
-                    <xs:element ref="system-err" />
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="type" type="xs:string"/>
-            <xs:attribute name="message" type="xs:string"/>
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="testcase">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="skipped"/>
-                    <xs:element ref="error"/>
-                    <xs:element ref="failure"/>
-                    <xs:element ref="rerunFailure" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element ref="rerunError" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element ref="flakyFailure" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element ref="flakyError" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element ref="system-out"/>
-                    <xs:element ref="system-err"/>
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:string" use="required"/>
-            <xs:attribute name="time" type="xs:string"/>
-            <xs:attribute name="classname" type="xs:string"/>
-            <xs:attribute name="group" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="testsuite">
-        <xs:complexType>
+   <xs:simpleType name="SUREFIRE_TIME">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?" />
+         <xs:pattern value="(\d+(\.\d+)?)" />
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:element name="failure">
+      <xs:complexType mixed="true">
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="error">
+      <xs:complexType mixed="true">
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="skipped">
+      <xs:complexType mixed="true">
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="properties">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="property" minOccurs="0" maxOccurs="unbounded" />
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="property">
+      <xs:complexType>
+         <xs:attribute name="name" type="xs:string" use="required" />
+         <xs:attribute name="value" type="xs:string" use="required" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="system-err" type="xs:string" />
+   <xs:element name="system-out" type="xs:string" />
+   <xs:element name="rerunFailure" nillable="true">
+      <xs:complexType mixed="true">
+         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="testsuite"/>
-                <xs:element ref="properties"/>
-                <xs:element ref="testcase"/>
-                <xs:element ref="system-out"/>
-                <xs:element ref="system-err"/>
+               <xs:element ref="system-out" />
+               <xs:element ref="system-err" />
             </xs:choice>
-            <xs:attribute name="name" type="xs:string" use="required"/>
-            <xs:attribute name="tests" type="xs:string" use="required"/>
-            <xs:attribute name="failures" type="xs:string" use="required"/>
-            <xs:attribute name="errors" type="xs:string" use="required"/>
-            <xs:attribute name="group" type="xs:string" />
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-            <xs:attribute name="skipped" type="xs:string" />
-            <xs:attribute name="timestamp" type="xs:string" />
-            <xs:attribute name="hostname" type="xs:string" />
-            <xs:attribute name="id" type="xs:string" />
-            <xs:attribute name="package" type="xs:string" />
-            <xs:attribute name="file" type="xs:string"/>
-            <xs:attribute name="log" type="xs:string"/>
-            <xs:attribute name="url" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="testsuites">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded" />
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:string" />
-            <xs:attribute name="time" type="SUREFIRE_TIME"/>
-            <xs:attribute name="tests" type="xs:string" />
-            <xs:attribute name="failures" type="xs:string" />
-            <xs:attribute name="errors" type="xs:string" />
-        </xs:complexType>
-    </xs:element>
-
+         </xs:sequence>
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="rerunError" nillable="true">
+      <xs:complexType mixed="true">
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="system-out" />
+               <xs:element ref="system-err" />
+            </xs:choice>
+         </xs:sequence>
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="flakyFailure" nillable="true">
+      <xs:complexType mixed="true">
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="system-out" />
+               <xs:element ref="system-err" />
+            </xs:choice>
+         </xs:sequence>
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="flakyError" nillable="true">
+      <xs:complexType mixed="true">
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="system-out" />
+               <xs:element ref="system-err" />
+            </xs:choice>
+         </xs:sequence>
+         <xs:attribute name="type" type="xs:string" />
+         <xs:attribute name="message" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="testcase">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="skipped" />
+               <xs:element ref="error" />
+               <xs:element ref="failure" />
+               <xs:element ref="rerunFailure" minOccurs="0" maxOccurs="unbounded" />
+               <xs:element ref="rerunError" minOccurs="0" maxOccurs="unbounded" />
+               <xs:element ref="flakyFailure" minOccurs="0" maxOccurs="unbounded" />
+               <xs:element ref="flakyError" minOccurs="0" maxOccurs="unbounded" />
+               <xs:element ref="system-out" />
+               <xs:element ref="system-err" />
+            </xs:choice>
+         </xs:sequence>
+         <xs:attribute name="assertions" type="xs:string" use="optional" />
+         <xs:attribute name="lineno" type="xs:string" use="optional" />
+         <xs:attribute name="name" type="xs:string" use="required" />
+         <xs:attribute name="time" type="xs:string" />
+         <xs:attribute name="classname" type="xs:string" />
+         <xs:attribute name="group" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="testsuite">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="testsuite" />
+            <xs:element ref="properties" />
+            <xs:element ref="testcase" />
+            <xs:element ref="system-out" />
+            <xs:element ref="system-err" />
+         </xs:choice>
+         <xs:attribute name="name" type="xs:string" use="required" />
+         <xs:attribute name="assertions" type="xs:string" use="optional" />
+         <xs:attribute name="filepath" type="xs:string" use="optional" />
+         <xs:attribute name="tests" type="xs:string" use="required" />
+         <xs:attribute name="failures" type="xs:string" use="required" />
+         <xs:attribute name="errors" type="xs:string" use="required" />
+         <xs:attribute name="group" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+         <xs:attribute name="skipped" type="xs:string" />
+         <xs:attribute name="timestamp" type="xs:string" />
+         <xs:attribute name="hostname" type="xs:string" />
+         <xs:attribute name="id" type="xs:string" />
+         <xs:attribute name="package" type="xs:string" />
+         <xs:attribute name="file" type="xs:string" />
+         <xs:attribute name="log" type="xs:string" />
+         <xs:attribute name="url" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="testsuites">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded" />
+         </xs:sequence>
+         <xs:attribute name="name" type="xs:string" />
+         <xs:attribute name="time" type="SUREFIRE_TIME" />
+         <xs:attribute name="tests" type="xs:string" />
+         <xs:attribute name="failures" type="xs:string" />
+         <xs:attribute name="errors" type="xs:string" />
+      </xs:complexType>
+   </xs:element>
 </xs:schema>


### PR DESCRIPTION
Added pattern match in (SUREFIRE_TIME) for duration; 'lineno' attribute in testcase, and 'filepath' attribute in testsuite to support Ruby minitest (5.11.3)/minitest-reporter (1.3.4) output.  Our company is using a custom 'patch' of xunit 1.104 version to get the test reporting to work and would like to be able to upgrade latest.

Test Output:
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
   <testsuite name="AppTest" filepath="/path/jenkins/workspace/myproject/PR_build/test/app_test.rb" skipped="0" failures="0" errors="0" tests="1" assertions="2" time="0.06244511529803276">
      <testcase name="test_mintest_output" lineno="46" classname="AppTest" assertions="2" time="0.06244511529803276" />
   </testsuite>
</testsuites>