### PR TITLE
JENKINS-53635 - xunit step failure is not displayed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitPublisher.java
@@ -164,6 +164,7 @@ public class XUnitPublisher extends Recorder implements SimpleBuildStep {
             // also if we throws AbortException the all publisher steps are always performed. I prefer hide the stacktrace.
             listener.error("The plugin hasn't been performed correctly: " + e.getMessage());
             build.setResult(Result.FAILURE);
+            throw e;
         }
     }
 


### PR DESCRIPTION
Simply throws the exception to ensure it can be handled upstream.