### PR TITLE
Don't traverse symlinks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorService.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorService.java
@@ -70,6 +70,7 @@ public class XUnitReportProcessorService implements Serializable {
         String toolName = xUnitToolInfo.getInputMetric().getLabel();
 
         FileSet fs = Util.createFileSet(parentPath, pattern);
+        fs.setFollowSymlinks(false) // Without this, we could traverse past project boundry if a bad symlink exists
         DirectoryScanner ds = fs.getDirectoryScanner();
         String[] xunitFiles = ds.getIncludedFiles();
 


### PR DESCRIPTION
We found an instance where a user was symlinking a directory to `../../../` which was past the boundary of their project. This caused the plugin to traverse all projects on the node looking for xunit files. By not following symlinks, we stop this behavior.