### PR TITLE
Update cppunit-1.0.xsd

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/cppunit-1.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/cppunit-1.0.xsd
@@ -173,7 +173,6 @@
                     <xs:complexType mixed="true"/>
                 </xs:element>
                <xs:element name="Project">
-                    <xs:complexType mixed="true"/>
                     <xs:complexType mixed="true">
                       <xs:sequence>
                         <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip" />

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/cppunit-1.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/cppunit-1.0.xsd
@@ -172,8 +172,13 @@
                 <xs:element name="Author">
                     <xs:complexType mixed="true"/>
                 </xs:element>
-                <xs:element name="Project">
+               <xs:element name="Project">
                     <xs:complexType mixed="true"/>
+                    <xs:complexType mixed="true">
+                      <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip" />
+                      </xs:sequence>
+                    </xs:complexType>
                 </xs:element>
                 <xs:element name="Date">
                     <xs:complexType mixed="true"/>


### PR DESCRIPTION
The SuiteInfo/Projects of cppunit-1.0.xsd supports now an arbitrary number of sub elements with arbitrary types.
This allows to add user defined tags like Version, Used compiler, Url etc. to the unittest.xml created by cppunit.