### PR TITLE
Replace deprecated code

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -267,7 +267,7 @@ public class XUnitProcessor {
     }
 
     private String getUserStylesheet(final TestType tool) throws IOException, InterruptedException {
-        File userContent = new File(Jenkins.getInstance().getRootDir(), "userContent");
+        File userContent = new File(Jenkins.get().getRootDir(), "userContent");
 
         InputMetricXSL inputMetricXSL = (InputMetricXSL) tool.getInputMetric();
         FilePath xslUserContent = new FilePath(new File(userContent, inputMetricXSL.getUserContentXSLDirRelativePath()));

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
@@ -62,11 +62,11 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
     @SuppressWarnings("unchecked")
     @Override
     public Descriptor<XUnitThreshold> getDescriptor() {
-        return Jenkins.getActiveInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     public static DescriptorExtensionList<XUnitThreshold, XUnitThresholdDescriptor<?>> all() {
-        return Jenkins.getActiveInstance().<XUnitThreshold, XUnitThresholdDescriptor<?>> getDescriptorList(XUnitThreshold.class);
+        return Jenkins.get().<XUnitThreshold, XUnitThresholdDescriptor<?>> getDescriptorList(XUnitThreshold.class);
     }
 
     public String getUnstableThreshold() {

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThresholdDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThresholdDescriptor.java
@@ -44,7 +44,7 @@ public abstract class XUnitThresholdDescriptor<T extends XUnitThreshold> extends
     }
 
     public static DescriptorExtensionList<XUnitThreshold, XUnitThresholdDescriptor<?>> all() {
-        return Jenkins.getActiveInstance().getDescriptorList(XUnitThreshold.class);
+        return Jenkins.get().getDescriptorList(XUnitThreshold.class);
     }
 
     public abstract String getUnstableThresholdImgTitle();

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitSerialisationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitSerialisationTest.java
@@ -67,6 +67,7 @@ public class XUnitSerialisationTest {
         verifyJUnitTool(xunitPublisher.getTools()[0]);
     }
 
+    @SuppressWarnings("deprecation") //Testing for backwards compatibility
     @LocalData("builder_1_103")
     @Test
     public void verify_builder_compatible_before_1_103() throws Exception {


### PR DESCRIPTION
Use get where appropriate and Suppress the warning on testing deprecated code.