### PR TITLE
Add optional warnings attribute to PHPUnit xsd testsuite element

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-2.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-2.0.xsd
@@ -105,6 +105,7 @@ THE SOFTWARE.
             <xs:attribute name="tests" type="xs:string" use="required"/>
             <xs:attribute name="failures" type="xs:string" use="optional"/>
             <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="warnings" type="xs:string" use="optional"/>
             <xs:attribute name="assertions" type="xs:string" use="optional"/>
             <xs:attribute name="skipped" type="xs:string" use="optional"/>
             <xs:attribute name="skip" type="xs:string" use="optional"/>


### PR DESCRIPTION
Please see https://github.com/sebastianbergmann/phpunit/issues/3913 for background.

PHPUnit 8.4.2, released today, includes a `warnings` attribute of `testsuite` in junit log files.