### PR TITLE
PHPUnit: Support for warnings (PHPUnit 8.4.2)

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
@@ -73,7 +73,14 @@ THE SOFTWARE.
                 </xsl:attribute>
 
                 <xsl:attribute name="errors">
-                    <xsl:value-of select="@errors"/>
+                    <xsl:choose>
+                        <xsl:when test="string(@warnings) != ''">
+                            <xsl:value-of select="@errors + @warnings"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="@errors"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:attribute>
 
                 <xsl:attribute name="skipped">
@@ -136,6 +143,20 @@ THE SOFTWARE.
                                 </xsl:attribute>
 
                                 <xsl:value-of select="error"/>
+                            </xsl:element>
+                        </xsl:if>
+
+                        <xsl:if test="warning">
+                            <xsl:element name="error">
+                                <xsl:attribute name="message">
+                                    <xsl:value-of select="warning/@message"/>
+                                </xsl:attribute>
+
+                                <xsl:attribute name="type">
+                                    <xsl:value-of select="warning/@type"/>
+                                </xsl:attribute>
+
+                                <xsl:value-of select="warning"/>
                             </xsl:element>
                         </xsl:if>
 

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
@@ -139,6 +139,12 @@ THE SOFTWARE.
                             </xsl:element>
                         </xsl:if>
 
+                        <xsl:if test="warning">
+                            <xsl:element name="system-err">
+                                <xsl:value-of select="warning"/>
+                            </xsl:element>
+                        </xsl:if>
+
                         <xsl:if test="skipped">
                             <xsl:element name="skipped" />
                         </xsl:if>

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0-to-junit.xsl
@@ -73,14 +73,7 @@ THE SOFTWARE.
                 </xsl:attribute>
 
                 <xsl:attribute name="errors">
-                    <xsl:choose>
-                        <xsl:when test="string(@warnings) != ''">
-                            <xsl:value-of select="@errors + @warnings"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="@errors"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
+                    <xsl:value-of select="@errors"/>
                 </xsl:attribute>
 
                 <xsl:attribute name="skipped">
@@ -143,20 +136,6 @@ THE SOFTWARE.
                                 </xsl:attribute>
 
                                 <xsl:value-of select="error"/>
-                            </xsl:element>
-                        </xsl:if>
-
-                        <xsl:if test="warning">
-                            <xsl:element name="error">
-                                <xsl:attribute name="message">
-                                    <xsl:value-of select="warning/@message"/>
-                                </xsl:attribute>
-
-                                <xsl:attribute name="type">
-                                    <xsl:value-of select="warning/@type"/>
-                                </xsl:attribute>
-
-                                <xsl:value-of select="warning"/>
                             </xsl:element>
                         </xsl:if>
 

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0.xsd
@@ -38,6 +38,13 @@ THE SOFTWARE.
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="warning">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="skipped">
         <xs:complexType mixed="true">
             <xs:attribute name="message" type="xs:string" use="optional"/>
@@ -71,6 +78,7 @@ THE SOFTWARE.
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="warning" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
@@ -106,6 +114,7 @@ THE SOFTWARE.
             <xs:attribute name="tests" type="xs:string" use="required"/>
             <xs:attribute name="failures" type="xs:string" use="optional"/>
             <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="warnings" type="xs:string" use="optional"/>
             <xs:attribute name="assertions" type="xs:string" use="optional"/>
             <xs:attribute name="skipped" type="xs:string" use="optional"/>
             <xs:attribute name="skip" type="xs:string" use="optional"/>

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/PHPUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/PHPUnitTest.java
@@ -45,6 +45,7 @@ public class PHPUnitTest extends AbstractTest {
                                               { "JENKINS-42715 skipped test using PHPUnit 5.4", 8 }, //
                                               { "JENKINS-42715 skipped test using PHPUnit 6+", 9 }, //
                                               { "JENKINS-27494 feature attribute", 10 }, //
+                                              { "PHPUnit 4.8.2 warnings", 11 }, //
         });
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/input.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="acceptance (jenkins)" tests="22" assertions="1922" failures="0" errors="1" warnings="2" time="1344.141643">
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="baseFlowTest" class="CommercialCombinedCest" feature="Step 1 - Create original quote" assertions="144" time="248.535834"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="baseFlowMTATest" class="CommercialCombinedCest" feature="Step 1 - Create MTA quote" assertions="96" time="92.421625"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="baseFlowSecondMTATest" class="CommercialCombinedCest" feature="Step 1 - Create second MTA quote" assertions="35" time="57.400482"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="baseFlowRenewalTest" class="CommercialCombinedCest" feature="Step 1 - Create Renewal quote" assertions="73" time="61.748391"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="baseFlowCancellationMTATest" class="CommercialCombinedCest" feature="Step 1 - Create Cancellation MTA quote" assertions="70" time="72.759595"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="ccSovereignBordereauReport" class="CommercialCombinedCest" feature="cc sovereign bordereau report" assertions="202" time="27.255718"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialCombinedCest.php" name="ccFaradayBordereauReport" class="CommercialCombinedCest" feature="cc faraday bordereau report" assertions="172" time="25.275946"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialGeneralLiabilityCest.php" name="baseFlowTest" class="CommercialGeneralLiabilityCest" feature="Step 1 - Create CGL quote" assertions="87" time="96.697882"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialGeneralLiabilityCest.php" name="baseFlowMTATest" class="CommercialGeneralLiabilityCest" feature="Step 1 - Create MTA quote" assertions="72" time="59.107361"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialGeneralLiabilityCest.php" name="baseFlowSecondMtaTest" class="CommercialGeneralLiabilityCest" feature="Step 1 - Create second MTA quote" assertions="35" time="46.404840"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialGeneralLiabilityCest.php" name="baseFlowNotTakenUpCancellationTest" class="CommercialGeneralLiabilityCest" feature="Step 1 - Create Cancellation MTA quote" assertions="69" time="52.691657"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CommercialGeneralLiabilityCest.php" name="cglSovereignBordereauReport" class="CommercialGeneralLiabilityCest" feature="cgl sovereign bordereau report" assertions="112" time="17.600964"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CourseOfConstructionCest.php" name="baseFlowTest" class="CourseOfConstructionCest" feature="Step 1 - Create COC quote" assertions="83" time="91.188082"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CourseOfConstructionCest.php" name="baseFlowMTATest" class="CourseOfConstructionCest" feature="Step 1 - Create MTA quote" assertions="70" time="64.456707"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CourseOfConstructionCest.php" name="cocSovereignBordereauReport" class="CourseOfConstructionCest" feature="coc sovereign bordereau report" assertions="112" time="16.639480"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/CourseOfConstructionCest.php" name="cocFaradayBordereauReport" class="CourseOfConstructionCest" feature="coc faraday bordereau report" assertions="124" time="18.844772"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/OpenMarketProductCest.php" name="baseFlowTest" class="OpenMarketProductCest" feature="Step 1 - Create original quote" assertions="99" time="94.269593"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/OpenMarketProductCest.php" name="baseFlowMTATest" class="OpenMarketProductCest" feature="Step 1 - Create MTA quote" assertions="67" time="54.826547"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/OpenMarketProductCest.php" name="baseFlowSecondMTATest" class="OpenMarketProductCest" feature="Step 1 - Create second MTA quote" assertions="59" time="46.877084"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/OpenMarketProductCest.php" name="baseFlowRenewalTest" class="OpenMarketProductCest" feature="Step 1 - Create Renewal quote" assertions="71" time="47.085328"/>
+    <testcase file="/var/www/insly/tests/acceptance/Ches/OpenMarketProductCest.php" name="baseFlowCancellationMTATest" class="OpenMarketProductCest" feature="Step 1 - Create Cancellation MTA quote" assertions="70" time="51.942756"/>
+    <testcase file="/var/www/insly/tests/acceptance/Signup/signupBaseCest.php" name="baseTestInstanceCreation" class="Signup\signupBaseCest" feature="base test instance creation" assertions="0" time="0.110998">
+      <error type="Facebook\WebDriver\Exception\UnknownServerException">signupBaseCest: Base test instance creation
+Facebook\WebDriver\Exception\UnknownServerException: unknown error: unhandled inspector error: {"code":-32000,"message":"Cannot navigate to invalid URL"}
+  (Session info: chrome=68.0.3440.84)
+  (Driver info: chromedriver=2.41.578700 (2f1ed5f9343c13f73144538f15c00b370eda6706),platform=Linux 4.14.91+ x86_64)
+
+/var/www/insly/vendor/facebook/webdriver/lib/Exception/WebDriverException.php:114
+/var/www/insly/vendor/facebook/webdriver/lib/Remote/HttpCommandExecutor.php:326
+/var/www/insly/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:547
+/var/www/insly/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:226
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Module/WebDriver.php:891
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Step.php:265
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Scenario.php:72
+/var/www/insly/tests/_support/_generated/AcceptanceTesterActions.php:283
+/var/www/insly/tests/_support/Page/Signup/MainPage.php:19
+/var/www/insly/tests/acceptance/Signup/signupBaseCest.php:25
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Lib/Di.php:127
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:138
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:150
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:82
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Test.php:89
+/var/www/insly/vendor/codeception/phpunit-wrapper/src/Runner.php:110
+/var/www/insly/vendor/codeception/codeception/src/Codeception/SuiteManager.php:158
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Codecept.php:192
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Codecept.php:181
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Command/Run.php:495
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Command/Run.php:390
+/var/www/insly/vendor/symfony/console/Command/Command.php:255
+/var/www/insly/vendor/symfony/console/Application.php:901
+/var/www/insly/vendor/symfony/console/Application.php:262
+/var/www/insly/vendor/symfony/console/Application.php:145
+/var/www/insly/vendor/codeception/codeception/src/Codeception/Application.php:108
+</error>
+    </testcase>
+    <testcase name="testWarning" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" file="/var/test/StatusTest.php" line="42" assertions="0" time="42.001">
+      <warning type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarning
+
+        %s%eStatusTest.php:%d
+      </warning>
+    </testcase>
+    <testcase name="testWarningWithMessage" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" file="/var/test/StatusTest.php" line="42" assertions="0" time="42.002">
+      <warning type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarningWithMessage
+        warning with custom message
+
+        %s%eStatusTest.php:%d
+      </warning>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite name="acceptance (jenkins)" tests="22" failures="0" errors="3" skipped="0" time="1344.142">
+    <testsuite name="acceptance (jenkins)" tests="22" failures="0" errors="1" skipped="0" time="1344.142">
         <testcase classname="CommercialCombinedCest" name="baseFlowTest" time="248.536" />
         <testcase classname="CommercialCombinedCest" name="baseFlowMTATest" time="92.422" />
         <testcase classname="CommercialCombinedCest" name="baseFlowSecondMTATest" time="57.400" />
@@ -56,19 +56,7 @@
                 /var/www/insly/vendor/codeception/codeception/src/Codeception/Application.php:108
             </error>
         </testcase>
-        <testcase name="testWarning" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.001">
-            <error message="" type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarning
-
-                %s%eStatusTest.php:%d
-            </error>
-        </testcase>
-        <testcase name="testWarningWithMessage" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.002">
-            <error message="" type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarningWithMessage
-                warning with custom message
-
-                %s%eStatusTest.php:%d
-            </error>
-        </testcase>
-
+        <testcase name="testWarning" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.001" />
+        <testcase name="testWarningWithMessage" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.002" />
     </testsuite>
 </testsuites>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="acceptance (jenkins)" tests="22" failures="0" errors="3" skipped="0" time="1344.142">
+        <testcase classname="CommercialCombinedCest" name="baseFlowTest" time="248.536" />
+        <testcase classname="CommercialCombinedCest" name="baseFlowMTATest" time="92.422" />
+        <testcase classname="CommercialCombinedCest" name="baseFlowSecondMTATest" time="57.400" />
+        <testcase classname="CommercialCombinedCest" name="baseFlowRenewalTest" time="61.748" />
+        <testcase classname="CommercialCombinedCest" name="baseFlowCancellationMTATest" time="72.760" />
+        <testcase classname="CommercialCombinedCest" name="ccSovereignBordereauReport" time="27.256" />
+        <testcase classname="CommercialCombinedCest" name="ccFaradayBordereauReport" time="25.276" />
+        <testcase classname="CommercialGeneralLiabilityCest" name="baseFlowTest" time="96.698" />
+        <testcase classname="CommercialGeneralLiabilityCest" name="baseFlowMTATest" time="59.107" />
+        <testcase classname="CommercialGeneralLiabilityCest" name="baseFlowSecondMtaTest" time="46.405" />
+        <testcase classname="CommercialGeneralLiabilityCest" name="baseFlowNotTakenUpCancellationTest" time="52.692" />
+        <testcase classname="CommercialGeneralLiabilityCest" name="cglSovereignBordereauReport" time="17.601" />
+        <testcase classname="CourseOfConstructionCest" name="baseFlowTest" time="91.188" />
+        <testcase classname="CourseOfConstructionCest" name="baseFlowMTATest" time="64.457" />
+        <testcase classname="CourseOfConstructionCest" name="cocSovereignBordereauReport" time="16.639" />
+        <testcase classname="CourseOfConstructionCest" name="cocFaradayBordereauReport" time="18.845" />
+        <testcase classname="OpenMarketProductCest" name="baseFlowTest" time="94.270" />
+        <testcase classname="OpenMarketProductCest" name="baseFlowMTATest" time="54.827" />
+        <testcase classname="OpenMarketProductCest" name="baseFlowSecondMTATest" time="46.877" />
+        <testcase classname="OpenMarketProductCest" name="baseFlowRenewalTest" time="47.085" />
+        <testcase classname="OpenMarketProductCest" name="baseFlowCancellationMTATest" time="51.943" />
+        <testcase classname="Signup\signupBaseCest" name="baseTestInstanceCreation" time="0.111">
+            <error message="" type="Facebook\WebDriver\Exception\UnknownServerException">signupBaseCest: Base test instance creation
+                Facebook\WebDriver\Exception\UnknownServerException: unknown error: unhandled inspector error: {"code":-32000,"message":"Cannot navigate to invalid URL"}
+                (Session info: chrome=68.0.3440.84)
+                (Driver info: chromedriver=2.41.578700 (2f1ed5f9343c13f73144538f15c00b370eda6706),platform=Linux 4.14.91+ x86_64)
+
+                /var/www/insly/vendor/facebook/webdriver/lib/Exception/WebDriverException.php:114
+                /var/www/insly/vendor/facebook/webdriver/lib/Remote/HttpCommandExecutor.php:326
+                /var/www/insly/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:547
+                /var/www/insly/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:226
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Module/WebDriver.php:891
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Step.php:265
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Scenario.php:72
+                /var/www/insly/tests/_support/_generated/AcceptanceTesterActions.php:283
+                /var/www/insly/tests/_support/Page/Signup/MainPage.php:19
+                /var/www/insly/tests/acceptance/Signup/signupBaseCest.php:25
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Lib/Di.php:127
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:138
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:150
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Cest.php:82
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Test/Test.php:89
+                /var/www/insly/vendor/codeception/phpunit-wrapper/src/Runner.php:110
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/SuiteManager.php:158
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Codecept.php:192
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Codecept.php:181
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Command/Run.php:495
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Command/Run.php:390
+                /var/www/insly/vendor/symfony/console/Command/Command.php:255
+                /var/www/insly/vendor/symfony/console/Application.php:901
+                /var/www/insly/vendor/symfony/console/Application.php:262
+                /var/www/insly/vendor/symfony/console/Application.php:145
+                /var/www/insly/vendor/codeception/codeception/src/Codeception/Application.php:108
+            </error>
+        </testcase>
+        <testcase name="testWarning" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.001">
+            <error message="" type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarning
+
+                %s%eStatusTest.php:%d
+            </error>
+        </testcase>
+        <testcase name="testWarningWithMessage" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.002">
+            <error message="" type="PHPUnit\Framework\Warning">PHPUnit\SelfTest\Basic\StatusTest::testWarningWithMessage
+                warning with custom message
+
+                %s%eStatusTest.php:%d
+            </error>
+        </testcase>
+
+    </testsuite>
+</testsuites>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/phpunit/testcase11/result.xml
@@ -56,7 +56,19 @@
                 /var/www/insly/vendor/codeception/codeception/src/Codeception/Application.php:108
             </error>
         </testcase>
-        <testcase name="testWarning" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.001" />
-        <testcase name="testWarningWithMessage" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.002" />
+        <testcase name="testWarning" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.001">
+            <system-err>PHPUnit\SelfTest\Basic\StatusTest::testWarning
+
+                %s%eStatusTest.php:%d
+            </system-err>
+        </testcase>
+        <testcase name="testWarningWithMessage" classname="PHPUnit\SelfTest\Basic\StatusTest" time="42.002">
+            <system-err>PHPUnit\SelfTest\Basic\StatusTest::testWarningWithMessage
+                warning with custom message
+
+                %s%eStatusTest.php:%d
+            </system-err>
+        </testcase>
+
     </testsuite>
 </testsuites>


### PR DESCRIPTION
The previous PR (#78) appears to have 2 issues:

* The change was only made to an older phpunit xsd file, not the "current" 4.0 version that is used when using `tools: [ PHPUnit(...) ]` so the issue isn't fixed in this case
* Warnings are generally serious errors that should be fixed, so they're converted to errors (since as far as I can tell JUnit's file format doesn't support warnings or any similar level). This should ensure the messages are included in the report (but since they don't affect the failure count, you should still be able to ignore them if you wish)