### PR TITLE
Add optional testcase attributes back

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -97,6 +97,9 @@ THE SOFTWARE.
                     <xs:element ref="system-err"/>
                 </xs:choice>
             </xs:sequence>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="time" type="xs:string"/>
             <xs:attribute name="classname" type="xs:string"/>


### PR DESCRIPTION
These attributes were present from 2014-2018 on the testcase element.
Tools other than maven surefire or ant tasks use the XSD file to build a XML report file that xunit plugin can read.

https://github.com/jenkinsci/xunit-plugin/blob/14c6e39c38408b9ed6280361484a13c6f5becca7/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd

xunit 2.2.4 removed those optional attributes.

`unittest-xml-reporting` is a python library that tries to generate xml report using that older schema definition.
https://github.com/xmlrunner/unittest-xml-reporting/issues/201