### PR TITLE
Support skipped BoostTest suites and cases in XML

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.2-to-junit-4.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.2-to-junit-4.xsl
@@ -67,7 +67,9 @@ THE SOFTWARE.
 
             <xsl:attribute name="name">MergedTestSuite</xsl:attribute>
 
-            <xsl:attribute name="skipped">0</xsl:attribute>
+            <xsl:attribute name="skipped">
+                <xsl:value-of select="count(//TestCase[@skipped='yes'])"/>
+            </xsl:attribute>
 
             <xsl:for-each select="//TestCase">
                 <xsl:call-template name="testCase"/>
@@ -217,7 +219,10 @@ THE SOFTWARE.
 
 
             <xsl:attribute name="time">
-                <xsl:value-of select="$time div 1000000"/>
+                <xsl:choose>
+                    <xsl:when test="TestingTime"><xsl:value-of select="$time div 1000000"/></xsl:when>
+                    <xsl:otherwise>0.000</xsl:otherwise>
+                </xsl:choose>
             </xsl:attribute>
 
             <xsl:variable name="nbErrors" select="count(Error)"/>
@@ -237,6 +242,9 @@ THE SOFTWARE.
                 </xsl:when>
             </xsl:choose>
 
+            <xsl:if test="@skipped">
+                <skipped />
+            </xsl:if>
 
             <xsl:if test="(count(child::Info)+ count(child::Warning) + count(child::Message))>0">
                 <xsl:element name="system-out">

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -113,9 +113,11 @@ THE SOFTWARE.
                     <xs:element ref="Exception" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element ref="Warning" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:choice>
-                <xs:element ref="TestingTime" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="TestingTime" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="reason" type="xs:string" use="optional"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
             <xs:attribute name="line" type="xs:integer" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>
@@ -160,6 +162,8 @@ THE SOFTWARE.
                 <xs:element ref="Message" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="reason" type="xs:string" use="optional"/>
             <xs:attribute name="result" type="xs:string" use="optional"/>
             <xs:attribute name="line" type="xs:integer" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
@@ -55,7 +55,8 @@ public class BoostTestTest extends AbstractTest {
                                               { "JENKINS-42031", 18 }, //
                                               { "testcase19", 19 }, //
                                               { "autotest", 20 }, //
-                                              { "autotest-multiple", 21 } //
+                                              { "autotest-multiple", 21 }, //
+                                              { "skipped", 22 } //
         });
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/input.xml
@@ -1,0 +1,12 @@
+<TestLog>
+    <TestSuite name="Master Test Suite">
+        <TestSuite name="root" file="test.cpp" line="47">
+            <TestSuite name="ts1" skipped="yes" reason="precondition failed"/>
+            <TestSuite name="ts2" file="test.cpp" line="57">
+                <TestCase name="test4" skipped="yes" reason="precondition failed"/>
+                <TestCase name="test5" skipped="yes" reason="precondition failed"/>
+                <TestCase name="test6" skipped="yes" reason="precondition failed"/>
+            </TestSuite>
+        </TestSuite>
+    </TestSuite>
+</TestLog>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/result.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite tests="3" errors="0" failures="0" name="MergedTestSuite" skipped="3">
+    <testcase classname="Master.Test.Suite.root.ts2" name="test4" time="0.000">
+        <skipped/>
+    </testcase>
+    <testcase classname="Master.Test.Suite.root.ts2" name="test5" time="0.000">
+        <skipped/>
+    </testcase>
+    <testcase classname="Master.Test.Suite.root.ts2" name="test6" time="0.000">
+        <skipped/>
+    </testcase>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/test.cpp
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase22/test.cpp
@@ -1,0 +1,71 @@
+#include <boost/test/included/unit_test.hpp>
+
+using namespace boost::unit_test;
+
+int add(int i, int j) { return i+j; }
+
+static void test1()
+{
+    BOOST_CHECK_EQUAL(add(2, 2), 4);
+}
+
+static void test2()
+{
+    BOOST_CHECK_EQUAL(add(2, 3), 4);
+}
+
+static void test3()
+{
+    BOOST_FAIL("un test failed");
+}
+
+static void test4()
+{
+    BOOST_CHECK_EQUAL(add(2, 2), 4);
+}
+
+static void test5()
+{
+    BOOST_CHECK_EQUAL(add(2, 3), 4);
+}
+
+static void test6()
+{
+    BOOST_FAIL("un test failed");
+}
+
+struct returnFalse{
+    assertion_result operator()(test_unit_id)
+    {
+        return assertion_result(false);
+    }
+};
+
+test_suite *
+init_unit_test_suite(int, char ** const)
+{
+    test_suite* ts_root = BOOST_TEST_SUITE("root");
+
+    test_suite* ts1 = BOOST_TEST_SUITE("ts1");
+    ts1->add_precondition(returnFalse());
+    ts1->add(BOOST_TEST_CASE(&test1));
+    ts1->add(BOOST_TEST_CASE(&test2));
+    ts1->add(BOOST_TEST_CASE(&test3));
+    //framework::master_test_suite().add(ts);
+    ts_root->add(ts1);
+
+    test_suite* ts2 = BOOST_TEST_SUITE("ts2");
+    auto tc1 = BOOST_TEST_CASE(&test4);
+    tc1->add_precondition(returnFalse());
+    ts2->add(tc1);
+    auto tc2 = BOOST_TEST_CASE(&test5);
+    tc2->add_precondition(returnFalse());
+    ts2->add(tc2);
+    auto tc3 = BOOST_TEST_CASE(&test6);
+    tc3->add_precondition(returnFalse());
+    ts2->add(tc3);
+    //framework::master_test_suite().add(ts);
+    ts_root->add(ts2);
+
+    return ts_root;
+}


### PR DESCRIPTION
Changes to BoostTest caused it to start outputting two new XML attributes for skipped TestSuites and TestCases. This broke processing in xunit-plugin of XML outputs with skipped TestSuites or TestCases. This pull request adds the two attributes "skipped" and "reason" to the XSD file for BoostTest output.