### PR TITLE
[JENKINS-61115] Boost test schema wrongfully rejects testsuite-scope exception

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -160,6 +160,7 @@ THE SOFTWARE.
                 <xs:element ref="TestCase" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="TestSuite" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="Message" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="Exception" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="skipped" type="xs:string" use="optional"/>


### PR DESCRIPTION
this schema shouldn't be rejecting valid boost xml reports.

Also see https://issues.jenkins-ci.org/browse/JENKINS-61115