### PR TITLE
Added missing properties to xUnit.NET report type

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/types/XUnitDotNetTestType.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/types/XUnitDotNetTestType.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.xunit.types;
 
 import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
-import org.jenkinsci.lib.dtkit.type.TestType;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -39,7 +38,7 @@ import hudson.Extension;
  * technology for unit testing C#, F#, VB.NET and other .NET languages.
  */
 @SuppressWarnings("serial")
-public class XUnitDotNetTestType extends TestType {
+public class XUnitDotNetTestType extends AbstractTestType {
 
     @DataBoundConstructor
     public XUnitDotNetTestType(String pattern) {


### PR DESCRIPTION
XUnitDotNetTestType inherited the wrong type. This causes all the additional properties on top of "pattern" to be missing for this test type.

This change fixes this issue.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
