### PR TITLE
Re-add call to XSTREAM.processAnnotations to ensure @XStreamAlias works

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/xunit/AliasInitializer.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/AliasInitializer.java
@@ -48,6 +48,7 @@ public class AliasInitializer {
             String className = getClassName(classType);
             Items.XSTREAM.alias(className, classType);
         }
+        Items.XSTREAM.processAnnotations(XUnitPublisher.class);
     }
 
     private static String getClassName(Class<? extends TestType> classType) {


### PR DESCRIPTION
This re-fixes PR #84 which seems to have been removed in commit aa47ac57dc3614f0ce7e6bf7cbf90ecdb05f59f6

After upgrading to Jenkins LTS 2.277.2 and xunit 3.0.1 the xunit plugin would no longer load config.xml where the tools were specified as types.  Example:

```
    <xunit plugin="xunit@2.3.9">
      <types>
        <NUnitJunitHudsonTestType>
          <pattern>products/connectagentes/logs/connectagentes-test-nunit-*.xml</pattern>
          <excludesPattern/>
          <skipNoTestFiles>false</skipNoTestFiles>
          <failIfNotNew>true</failIfNotNew>
          <deleteOutputFiles>true</deleteOutputFiles>
          <stopProcessingIfError>true</stopProcessingIfError>
        </NUnitJunitHudsonTestType>
      </types>
      <thresholds/>
      <thresholdMode>1</thresholdMode>
      <extraConfiguration>
        <testTimeMargin>3000</testTimeMargin>
        <sleepTime>0</sleepTime>
        <reduceLog>true</reduceLog>
        <followSymlink>true</followSymlink>
      </extraConfiguration>
      <testDataPublishers class="empty-set"/>
    </xunit>
```

Resulting in the following error:

```
11:27:56 ERROR: Build step failed with exception
11:27:56 java.lang.IllegalArgumentException: The tools section is required.
11:27:56 	at org.jenkinsci.plugins.xunit.XUnitProcessor.<init>(XUnitProcessor.java:139)
11:27:56 	at org.jenkinsci.plugins.xunit.XUnitPublisher.perform(XUnitPublisher.java:204)
11:27:56 	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
11:27:56 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:80)
11:27:56 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
11:27:56 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:803)
11:27:56 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:752)
11:27:56 	at hudson.model.Build$BuildExecution.post2(Build.java:177)
11:27:56 	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:697)
11:27:56 	at hudson.model.Run.execute(Run.java:1932)
11:27:56 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
11:27:56 	at hudson.model.ResourceController.execute(ResourceController.java:97)
11:27:56 	at hudson.model.Executor.run(Executor.java:429)
```

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
