### PR TITLE
BoostTest schema update to allow Context within an Exception

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/boosttest-1.5.0.xsd
@@ -74,6 +74,7 @@ THE SOFTWARE.
         <xs:complexType mixed="true">
             <xs:sequence>
                 <xs:element ref="LastCheckpoint" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="Context" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="line" type="xs:integer" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/BoostTestTest.java
@@ -56,7 +56,8 @@ public class BoostTestTest extends AbstractTest {
                                               { "testcase19", 19 }, //
                                               { "autotest", 20 }, //
                                               { "autotest-multiple", 21 }, //
-                                              { "skipped", 22 } //
+                                              { "skipped", 22 }, //
+                                              { "exception-context", 23 } //
         });
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/input.xml
@@ -1,0 +1,21 @@
+<TestLog>
+  <TestSuite name="MyTest">
+    <TestSuite name="MyTestCase" file="test.cpp" line="9">
+      <TestCase name="_0" file="test.cpp" line="9">
+        <Message file="test.cpp" line="14">
+          <![CDATA[testing]]>
+          <Context><Frame><![CDATA[sample = 1; ]]></Frame></Context>
+        </Message>
+        <TestingTime>99</TestingTime>
+      </TestCase>
+      <TestCase name="_1" file="test.cpp" line="9">
+        <Exception file="unknown location" line="0">
+          <![CDATA[signal: SIGABRT (application abort requested)]]>
+          <LastCheckpoint file="test.cpp" line="9"><![CDATA["MyTestCase" test entry]]></LastCheckpoint>
+          <Context><Frame><![CDATA[sample = 2; ]]></Frame></Context>
+        </Exception>
+        <TestingTime>225</TestingTime>
+      </TestCase>
+    </TestSuite>
+  </TestSuite>
+</TestLog>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/result.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite tests="2" errors="1" failures="0" name="MergedTestSuite" skipped="0">
+  <testcase classname="MyTest.MyTestCase.test" name="_0" time="0.000099">
+    <system-out>&#xD;[Message] -
+      testing
+
+    &#xD; == [File] - test.cpp&#xD; == [Line] - 14&#xD; == [Context] sample = 1; &#xD;</system-out>
+  </testcase>
+  <testcase classname="MyTest.MyTestCase.test" name="_1" time="0.000225">
+    <error>&#xD;[Exception] -
+      signal: SIGABRT (application abort requested)
+
+
+    "MyTestCase" test entry&#xD; == [File] - test.cpp&#xD; == [Line] - 9&#xD; == [Context] sample = 2; &#xD;</error>
+    <system-err>&#xD;[Exception] -
+      signal: SIGABRT (application abort requested)
+
+
+    "MyTestCase" test entry&#xD; == [File] - test.cpp&#xD; == [Line] - 9&#xD; == [Context] sample = 2; &#xD;</system-err>
+  </testcase>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/test.cpp
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/boosttest/testcase23/test.cpp
@@ -1,0 +1,16 @@
+#define BOOST_TEST_MODULE MyTest
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+
+using namespace boost::unit_test;
+
+std::vector<int> cases { 1, 2 };
+
+BOOST_DATA_TEST_CASE(MyTestCase, data::make(cases))
+{
+    if (sample == 2) {
+        assert(false);
+    }
+    BOOST_TEST_MESSAGE("testing");
+    BOOST_CHECK(sample == 1);
+}


### PR DESCRIPTION
Boost test will output a `<Context>` within an `<Exception>` in certain situations. It's most easily reproducible by using dataset fixtures. The context will be information about the current data sample. Without this fix, valid BoostTest XML output is rejected by the schema validator.