### PR TITLE
Make xunit compatible with playwright JUnit result xmls

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -141,6 +141,8 @@ THE SOFTWARE.
             <xs:attribute name="tests" type="xs:string" />
             <xs:attribute name="failures" type="xs:string" />
             <xs:attribute name="errors" type="xs:string" />
+            <xs:attribute name="id" type="xs:string" />
+            <xs:attribute name="skipped" type="xs:string" />
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
Add id and skipped properties for the testsuites junit result element

This is meant to make Playwright result xml parsable within Jenkins. See https://github.com/microsoft/playwright/issues/12344 for details.

Also see https://www.ibm.com/docs/de/developer-for-zos/14.1.0?topic=formats-junit-xml-format and https://llg.cubic.org/docs/junit/

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
