### PR TITLE
Adapt junit xsd for compatibility with playwright

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -141,6 +141,8 @@ THE SOFTWARE.
             <xs:attribute name="tests" type="xs:string" />
             <xs:attribute name="failures" type="xs:string" />
             <xs:attribute name="errors" type="xs:string" />
+            <xs:attribute name="id" type="xs:string" />
+            <xs:attribute name="skipped" type="xs:string" />
         </xs:complexType>
     </xs:element>
 

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/JUnitTypeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/JUnitTypeTest.java
@@ -43,7 +43,9 @@ public class JUnitTypeTest extends AbstractTest {
                                               { "test case 3", 3 }, //
                                               { "test case 4", 4 }, //
                                               { "support rerun of maven-surefire-plugin version", 5 }, //
-                                              { "support maven surefure report schema version 3", 6 }
+                                              { "support maven surefure report schema version 3", 6 },//
+                                              { "support playwright junit report", 7 }, //
+
         });
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/junit/testcase7/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/junit/testcase7/input.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites id="" name="" tests="32" failures="0" skipped="29" errors="0" time="13.353">
+    <testsuite name="autocomplete.gui.spec.ts" timestamp="1645616455044" hostname="" tests="3" failures="0" skipped="0" time="7.259" errors="0">
+        <testcase name="some description" classname="[chromium] › autocomplete.gui.spec.ts:61:3" time="2.882">
+            <system-out>
+                ...
+            </system-out>
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
Add id and skipped properties for the testsuites junit result element

This is meant to make Playwright result xml parsable within Jenkins. See https://github.com/microsoft/playwright/issues/12344 for details.

Also see https://www.ibm.com/docs/de/developer-for-zos/14.1.0?topic=formats-junit-xml-format and https://llg.cubic.org/docs/junit/

<!-- Please describe your pull request here. -->

- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ - ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
