### PR TITLE
JENKINS-66921 fix

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
@@ -88,8 +88,8 @@ THE SOFTWARE.
     </xsl:variable>
 
     <xsl:template match="/valgrindoutput">
-        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4), 0))" />
-        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4), 0))" />
+        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4), '00:00:00'))" />
+        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4), '00:00:00'))" />
 
         <xsl:element name="testsuite">
             <xsl:attribute name="name" select="concat('valgrind-', $tool)" />

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
@@ -88,8 +88,8 @@ THE SOFTWARE.
     </xsl:variable>
 
     <xsl:template match="/valgrindoutput">
-        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4), '00:00:00'))" />
-        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4), '00:00:00'))" />
+        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4)))" />
+        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4)))" />
 
         <xsl:element name="testsuite">
             <xsl:attribute name="name" select="concat('valgrind-', $tool)" />

--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/valgrind-1.0-to-junit.xsl
@@ -88,8 +88,8 @@ THE SOFTWARE.
     </xsl:variable>
 
     <xsl:template match="/valgrindoutput">
-        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4)))" />
-        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4)))" />
+        <xsl:variable name="startTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'RUNNING']/../time, 4), 0))" />
+        <xsl:variable name="endTime" select="xunit:millis-from-time(xunit:if-empty(substring(status/state[text() = 'FINISHED']/../time, 4), 0))" />
 
         <xsl:element name="testsuite">
             <xsl:attribute name="name" select="concat('valgrind-', $tool)" />

--- a/src/test/java/org/jenkinsci/plugins/xunit/types/ValgrindTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/types/ValgrindTest.java
@@ -36,7 +36,8 @@ public class ValgrindTest extends AbstractTest {
     @Parameters(name = "testcase{1}: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] { { "testcase1", 1 }, //
-                                              { "testcase2", 2 } //
+                                              { "testcase2", 2 }, //
+                                              { "testcase3", 3 } //
         });
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/valgrind/testcase3/input.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/valgrind/testcase3/input.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+
+<valgrindoutput>
+
+<protocolversion>4</protocolversion>
+<protocoltool>memcheck</protocoltool>
+
+<preamble>
+  <line>Memcheck, a memory error detector</line>
+  <line>Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.</line>
+  <line>Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info</line>
+  <line>Command: /some/workdir/some/builddir/some/subdir/some_test_binary --gtest_output=xml:/some/workdir/some/builddir/some/subdir/ut_result_some_test_binary.xml --gtest_filter=*</line>
+</preamble>
+
+<pid>399515</pid>
+<ppid>399466</ppid>
+<tool>memcheck</tool>
+
+<args>
+  <vargv>
+    <exe>/some/toolchain/some/sdk/bld-tools/sysroots/x86_64-pokysdk-linux/usr/lib/ld-2.28.so</exe>
+    <arg>--log-file=/some/workdir/some/builddir/Testing/Temporary/MemoryChecker.94.log</arg>
+    <arg>--error-exitcode=1</arg>
+    <arg>--gen-suppressions=all</arg>
+    <arg>--suppressions=/dev/null</arg>
+    <arg>--num-callers=30</arg>
+    <arg>--leak-check=full</arg>
+    <arg>--partial-loads-ok=no</arg>
+    <arg>--xml=yes</arg>
+    <arg>--xml-file=%p.%n.valgrind.xml</arg>
+    <arg>--suppressions=/some/workdir/test/valgrind_suppressions.txt</arg>
+  </vargv>
+  <argv>
+    <exe>/some/workdir/some/builddir/some/subdir/some_test_binary</exe>
+    <arg>--gtest_output=xml:/some/workdir/some/builddir/some/subdir/ut_result_some_test_binary.xml</arg>
+    <arg>--gtest_filter=*</arg>
+  </argv>
+</args>
+
+<fatal_signal>
+  <tid>1</tid>
+  <signo>6</signo>
+  <signame>SIGABRT</signame>
+  <sicode>-6</sicode>
+  <stack>
+    <frame>
+      <ip>0x914A4C0</ip>
+      <obj>/some/toolchain/some/other/sdk/os/sys-root/x86_64-pc-linux-gnu/usr/lib64/libc-2.28.so</obj>
+      <fn>raise</fn>
+      <dir>/usr/src/debug/glibc/2.28-r0/git/signal/../sysdeps/unix/sysv/linux</dir>
+      <file>raise.c</file>
+      <line>51</line>
+    </frame>
+    <frame>
+      <ip>0x9135522</ip>
+      <obj>/some/toolchain/some/other/sdk/os/sys-root/x86_64-pc-linux-gnu/usr/lib64/libc-2.28.so</obj>
+      <fn>abort</fn>
+      <dir>/usr/src/debug/glibc/2.28-r0/git/stdlib</dir>
+      <file>abort.c</file>
+      <line>79</line>
+    </frame>
+    <frame>
+      <ip>0xAD626B</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>oam::detail::AssertionFailed(char const*, char const*, char const*, long)</fn>
+    </frame>
+    <frame>
+      <ip>0x773ADA</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>std::vector&lt;std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;, std::allocator&lt;std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt; &gt; &gt; const&amp; some_component::sdk::core::GenericContainer::getObject&lt;std::vector&lt;std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;, std::allocator&lt;std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt; &gt; &gt; &gt;() const</fn>
+    </frame>
+    <frame>
+      <ip>0x774CD4</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>some_component::services::pm::scenarios::removal::CollectObjectsForUnitStepTests_ShouldNotFindObjectsIfServiceDoesNotSupportAny_Test::TestBody()</fn>
+    </frame>
+    <frame>
+      <ip>0x9A028E</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>void testing::internal::HandleSehExceptionsInMethodIfSupported&lt;testing::Test, void&gt;(testing::Test*, void (testing::Test::*)(), char const*)</fn>
+    </frame>
+    <frame>
+      <ip>0x999255</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>void testing::internal::HandleExceptionsInMethodIfSupported&lt;testing::Test, void&gt;(testing::Test*, void (testing::Test::*)(), char const*)</fn>
+    </frame>
+    <frame>
+      <ip>0x97795D</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>testing::Test::Run()</fn>
+    </frame>
+    <frame>
+      <ip>0x9781BD</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>testing::TestInfo::Run()</fn>
+    </frame>
+    <frame>
+      <ip>0x9787DC</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>testing::TestCase::Run()</fn>
+    </frame>
+    <frame>
+      <ip>0x97F061</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>testing::internal::UnitTestImpl::RunAllTests()</fn>
+    </frame>
+    <frame>
+      <ip>0x9A1431</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>bool testing::internal::HandleSehExceptionsInMethodIfSupported&lt;testing::internal::UnitTestImpl, bool&gt;(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)</fn>
+    </frame>
+    <frame>
+      <ip>0x99A0EB</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>bool testing::internal::HandleExceptionsInMethodIfSupported&lt;testing::internal::UnitTestImpl, bool&gt;(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)</fn>
+    </frame>
+    <frame>
+      <ip>0x97DDC1</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>testing::UnitTest::Run()</fn>
+    </frame>
+    <frame>
+      <ip>0x4C1094</ip>
+      <obj>/some/workdir/some/builddir/some/subdir/some_test_binary</obj>
+      <fn>main</fn>
+    </frame>
+  </stack>
+</fatal_signal>
+
+
+<status>
+  <state>FINISHED</state>
+  <time>00:00:00:45.808 </time>
+</status>
+
+<errorcounts>
+</errorcounts>
+
+<suppcounts>
+  <pair>
+    <count>609</count>
+    <name>DistName_constructor_from_liblim.so</name>
+  </pair>
+  <pair>
+    <count>2</count>
+    <name>registerMetaDescriptor_from_liblim.so</name>
+  </pair>
+  <pair>
+    <count>1</count>
+    <name>acquireTracerLock_from_lim</name>
+  </pair>
+  <pair>
+    <count>1</count>
+    <name>DistNameData_parentSlow_from_liblim.so</name>
+  </pair>
+  <pair>
+    <count>7892</count>
+    <name>gtest_print_std_function_Cond_conditional_jump_or_move_depends_on_unitialized_value</name>
+  </pair>
+  <pair>
+    <count>2690</count>
+    <name>gtest_print_std_function_Value8_conditional_jump_or_move_depends_on_unitialized_value</name>
+  </pair>
+</suppcounts>
+
+</valgrindoutput>
+

--- a/src/test/resources/org/jenkinsci/plugins/xunit/types/valgrind/testcase3/result.xml
+++ b/src/test/resources/org/jenkinsci/plugins/xunit/types/valgrind/testcase3/result.xml
@@ -1,0 +1,9 @@
+<testsuite name="valgrind-memcheck"
+           tests="1"
+           errors="0"
+           time="45.808"
+           failures="0">
+   <testcase xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xunit="http://www.xunit.org"
+             name="%p"/>
+</testsuite>


### PR DESCRIPTION
If the RUNNING (or FINISHED) node did not exist, it failed with below error:

> Conversion error: Invalid time "0" (hour must be two digits)

corrected default value for those items from 0 to '00:00:00'

https://issues.jenkins.io/browse/JENKINS-66921

tested manually by processing faulty valgrind reports (attached to above jira ticket) with https://www.freeformatter.com/xsl-transformer.html

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
