### PR TITLE
Removed 1 unnecessary stubbing in XUnitProcessorTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/xunit/SecondXUnitProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/SecondXUnitProcessorTest.java
@@ -23,32 +23,23 @@
  */
 package org.jenkinsci.plugins.xunit;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
-import org.jenkinsci.plugins.xunit.service.NoTestFoundException;
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.jenkinsci.plugins.xunit.service.XUnitToolInfo;
-import org.jenkinsci.plugins.xunit.service.XUnitTransformerCallable;
 import org.jenkinsci.plugins.xunit.types.AUnitJunitHudsonTestType;
 import org.jenkinsci.plugins.xunit.types.CppUnitJunitHudsonTestType;
 import org.jenkinsci.plugins.xunit.types.CustomType;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -61,9 +52,6 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.remoting.DelegatingCallable;
-import hudson.remoting.VirtualChannel;
-import hudson.tasks.junit.TestDataPublisher;
 import hudson.util.ReflectionUtils;
 
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)

--- a/src/test/java/org/jenkinsci/plugins/xunit/XUnitProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/XUnitProcessorTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
@@ -40,10 +39,8 @@ import org.hamcrest.CoreMatchers;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.jenkinsci.plugins.xunit.service.NoTestFoundException;
-import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.jenkinsci.plugins.xunit.service.XUnitToolInfo;
 import org.jenkinsci.plugins.xunit.service.XUnitTransformerCallable;
-import org.jenkinsci.plugins.xunit.types.AUnitJunitHudsonTestType;
 import org.jenkinsci.plugins.xunit.types.CppUnitJunitHudsonTestType;
 import org.jenkinsci.plugins.xunit.types.CustomType;
 import org.junit.Assert;
@@ -64,7 +61,6 @@ import hudson.model.TaskListener;
 import hudson.remoting.DelegatingCallable;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.junit.TestDataPublisher;
-import hudson.util.ReflectionUtils;
 
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class XUnitProcessorTest {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
In our analysis of the project, we observed that 
1 unnecessary stubbing which stubbed `getLogger` method in `XUnitProcessorTest.setUp` is created but is never executed by 2 tests `XUnitProcessorTest.user_XSL_override_embedded`, `XUnitProcessorTest.custom_tools_as_URL` and `XUnitProcessorTest.custom_tools_resolve_against_master`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
