### PR TITLE
Removed 1 unnecessary stubbing in XUnitReportProcessorTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/xunit/service/SecondXUnitReportProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/service/SecondXUnitReportProcessorTest.java
@@ -50,7 +50,7 @@ import com.google.inject.Singleton;
 
 import hudson.model.TaskListener;
 
-public class XUnitReportProcessorTest {
+public class SecondXUnitReportProcessorTest {
 
     private XUnitReportProcessorService xUnitReportProcessorService;
     @Rule
@@ -124,7 +124,6 @@ public class XUnitReportProcessorTest {
     @Before
     public void setup() {
         final TaskListener listenerMock = mock(TaskListener.class);
-        when(listenerMock.getLogger()).thenReturn(new PrintStream(new ByteArrayOutputStream()));
         xUnitReportProcessorService = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
@@ -136,13 +135,19 @@ public class XUnitReportProcessorTest {
     }
 
     @Test
-    public void findReportsOneFile() throws Exception {
-        File f1 = folderRule.newFile("a.txt");
+    public void isEmptyPattern() {
+        Assert.assertTrue(xUnitReportProcessorService.isEmptyPattern(null));
+        Assert.assertTrue(xUnitReportProcessorService.isEmptyPattern(""));
+        Assert.assertFalse(xUnitReportProcessorService.isEmptyPattern("abc"));
+    }
+
+    @Test(expected = NoTestFoundException.class)
+    public void verify_processor_throws_exception_if_no_reports_was_found() throws Exception {
         XUnitToolInfo xUnitToolInfoMock = mock(XUnitToolInfo.class);
         when(xUnitToolInfoMock.getInputMetric()).thenReturn(new MyInputMetric());
-        when(xUnitToolInfoMock.getPattern()).thenReturn("*.txt");
+        when(xUnitToolInfoMock.getPattern()).thenReturn("*.xml");
 
-        String[] xUnitFiles = xUnitReportProcessorService.findReports(f1.getParentFile(), xUnitToolInfoMock);
-        Assertions.assertThat(xUnitFiles).isNotEmpty().hasSize(1).contains(f1.getName());
+        xUnitReportProcessorService.findReports(folderRule.newFolder(), xUnitToolInfoMock);
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/xunit/service/SecondXUnitReportProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/service/SecondXUnitReportProcessorTest.java
@@ -26,11 +26,7 @@ package org.jenkinsci.plugins.xunit.service;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.PrintStream;
 
-import org.assertj.core.api.Assertions;
 import org.jenkinsci.lib.dtkit.descriptor.TestTypeDescriptor;
 import org.jenkinsci.lib.dtkit.model.InputMetricType;
 import org.jenkinsci.lib.dtkit.model.InputMetricXSL;

--- a/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xunit/service/XUnitReportProcessorTest.java
@@ -38,7 +38,6 @@ import org.jenkinsci.lib.dtkit.model.InputType;
 import org.jenkinsci.lib.dtkit.model.OutputMetric;
 import org.jenkinsci.lib.dtkit.type.TestType;
 import org.jenkinsci.plugins.xunit.types.model.JUnitModel;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

In our analysis of the project, we observed that 
1 unnecessary stubbing which stubbed `getLogger` method in `XUnitReportProcessorTest.setUp` is created but is never executed by 2 tests `XUnitReportProcessorTest.isEmptyPattern` and `XUnitReportProcessorTest.verify_processor_throws_exception_if_no_reports_was_found`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
