### PR TITLE
relaxing junit xml parsing - allow more decimals for time value

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:simpleType name="SUREFIRE_TIME">
         <xs:restriction base="xs:string">
-            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
+            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,9})?"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
got the following error when reading junit file with xunit.
`WARNING: At line 1 of file:/.../test-junit-report.xml:cvc-pattern-valid: Value '0.0026' is not facet-valid with respect to pattern '(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?' for type 'SUREFIRE_TIME'.`

the issue is clearly that 4 decimal digits are given for every time var.
after a quick online search i figured out that this is kind of a common issue. all sorts of junit "compatible" output libs add more decimal digits after the decimal point - which may make sense. I have seen up to 9.
also see https://github.com/catchorg/Catch2/issues/2221

This change will allow for 9 decimal digits.

### Testing done

did not actually test this exact change but tested the change on the exporting lib side.
commit found here: https://github.com/wingcon/junit-formatter/commit/4286be12926fdaa297e4802b58bcbfde2229f9f7

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [y] Link to relevant issues in GitHub or Jira
- [y] Link to relevant pull requests, esp. upstream and downstream changes
- [y] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
